### PR TITLE
[feature/5-create-entities] 신뢰점수 도메인 관련 엔티티, 레이어, 도메인 생성

### DIFF
--- a/src/main/java/com/example/demo/constant/ScoreTypeDistinguishCode.java
+++ b/src/main/java/com/example/demo/constant/ScoreTypeDistinguishCode.java
@@ -1,0 +1,8 @@
+package com.example.demo.constant;
+
+public enum ScoreTypeDistinguishCode {
+    PLUS,
+    MINUS,
+    BONUS,
+    ADMIN
+}

--- a/src/main/java/com/example/demo/controller/TrustScoreController.java
+++ b/src/main/java/com/example/demo/controller/TrustScoreController.java
@@ -1,0 +1,7 @@
+package com.example.demo.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TrustScoreController {
+}

--- a/src/main/java/com/example/demo/controller/TrustScoreHistoryController.java
+++ b/src/main/java/com/example/demo/controller/TrustScoreHistoryController.java
@@ -1,0 +1,7 @@
+package com.example.demo.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TrustScoreHistoryController {
+}

--- a/src/main/java/com/example/demo/controller/TrustScoreTypeController.java
+++ b/src/main/java/com/example/demo/controller/TrustScoreTypeController.java
@@ -1,0 +1,7 @@
+package com.example.demo.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TrustScoreTypeController {
+}

--- a/src/main/java/com/example/demo/dto/board/request/BoardCreateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/board/request/BoardCreateRequestDto.java
@@ -1,4 +1,4 @@
-package com.example.demo.dto.board.Request;
+package com.example.demo.dto.board.request;
 
 import java.util.List;
 import javax.validation.constraints.NotBlank;

--- a/src/main/java/com/example/demo/dto/board/request/BoardUpdateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/board/request/BoardUpdateRequestDto.java
@@ -1,4 +1,4 @@
-package com.example.demo.dto.board.Request;
+package com.example.demo.dto.board.request;
 
 import java.util.List;
 import javax.validation.constraints.NotBlank;

--- a/src/main/java/com/example/demo/dto/boardproject/request/BoardProjectCreateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/boardproject/request/BoardProjectCreateRequestDto.java
@@ -1,7 +1,7 @@
-package com.example.demo.dto.boardproject.Request;
+package com.example.demo.dto.boardproject.request;
 
-import com.example.demo.dto.board.Request.BoardCreateRequestDto;
-import com.example.demo.dto.project.Request.ProjectCreateRequestDto;
+import com.example.demo.dto.board.request.BoardCreateRequestDto;
+import com.example.demo.dto.project.request.ProjectCreateRequestDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/com/example/demo/dto/boardproject/request/BoardProjectUpdateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/boardproject/request/BoardProjectUpdateRequestDto.java
@@ -1,7 +1,7 @@
-package com.example.demo.dto.boardproject.Request;
+package com.example.demo.dto.boardproject.request;
 
-import com.example.demo.dto.board.Request.BoardUpdateRequestDto;
-import com.example.demo.dto.project.Request.ProjectUpdateRequestDto;
+import com.example.demo.dto.board.request.BoardUpdateRequestDto;
+import com.example.demo.dto.project.request.ProjectUpdateRequestDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/com/example/demo/dto/project/request/ProjectCreateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/project/request/ProjectCreateRequestDto.java
@@ -1,4 +1,4 @@
-package com.example.demo.dto.project.Request;
+package com.example.demo.dto.project.request;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/com/example/demo/dto/project/request/ProjectUpdateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/project/request/ProjectUpdateRequestDto.java
@@ -1,4 +1,4 @@
-package com.example.demo.dto.project.Request;
+package com.example.demo.dto.project.request;
 
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/example/demo/dto/trustscore/request/TrustScoreChangeRequestDto.java
+++ b/src/main/java/com/example/demo/dto/trustscore/request/TrustScoreChangeRequestDto.java
@@ -1,0 +1,26 @@
+package com.example.demo.dto.trustscore.request;
+
+import lombok.*;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class TrustScoreChangeRequestDto {
+    @NotNull
+    Long userId;
+    Long projectId;
+    Long milestoneId;
+    Long workId;
+    Boolean isPlus;
+    Boolean isNewUser;
+    Boolean isQuit;
+    Boolean isForceQuit;
+}
+
+/*
+1. 회원가입
+2. 업무평가
+3. 프로젝트 탈퇴
+4. 프로젝트 강제 탈퇴
+*/

--- a/src/main/java/com/example/demo/dto/trustscore/request/TrustScoreUpdateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/trustscore/request/TrustScoreUpdateRequestDto.java
@@ -23,4 +23,5 @@ public class TrustScoreUpdateRequestDto {
 2. 업무평가
 3. 프로젝트 탈퇴
 4. 프로젝트 강제 탈퇴
+5. 프로젝트 회원 이력
 */

--- a/src/main/java/com/example/demo/dto/trustscore/request/TrustScoreUpdateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/trustscore/request/TrustScoreUpdateRequestDto.java
@@ -6,7 +6,7 @@ import javax.validation.constraints.NotNull;
 @Getter
 @Setter
 @NoArgsConstructor
-public class TrustScoreChangeRequestDto {
+public class TrustScoreUpdateRequestDto {
     @NotNull
     Long userId;
     Long projectId;

--- a/src/main/java/com/example/demo/dto/trustscore/request/TrustScoreUpdateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/trustscore/request/TrustScoreUpdateRequestDto.java
@@ -17,11 +17,3 @@ public class TrustScoreUpdateRequestDto {
     Boolean isQuit;
     Boolean isForceQuit;
 }
-
-/*
-1. 회원가입
-2. 업무평가
-3. 프로젝트 탈퇴
-4. 프로젝트 강제 탈퇴
-5. 프로젝트 회원 이력
-*/

--- a/src/main/java/com/example/demo/model/BaseTimeEntity.java
+++ b/src/main/java/com/example/demo/model/BaseTimeEntity.java
@@ -10,7 +10,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-@EntityListeners(value = {AuditingEntityListener.class})
+@EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 @Getter
 @Setter
@@ -19,5 +19,6 @@ public abstract class BaseTimeEntity {
     @Column(updatable = false)
     private LocalDateTime createDate;
 
-    @LastModifiedDate private LocalDateTime updateDate;
+    @LastModifiedDate
+    private LocalDateTime updateDate;
 }

--- a/src/main/java/com/example/demo/model/TrustScore.java
+++ b/src/main/java/com/example/demo/model/TrustScore.java
@@ -3,15 +3,17 @@ package com.example.demo.model;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "trust_score")
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class TrustScore {
+public class TrustScore extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "trust_score_id")
@@ -23,7 +25,4 @@ public class TrustScore {
 
     @Column(name = "trust_score")
     private Long trustScore;
-
-    @Column(name = "update_date")
-    private LocalDateTime updateDate;
 }

--- a/src/main/java/com/example/demo/model/TrustScore.java
+++ b/src/main/java/com/example/demo/model/TrustScore.java
@@ -1,0 +1,29 @@
+package com.example.demo.model;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "trust_score")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TrustScore {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "trust_score_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "trust_score")
+    private Long trustScore;
+
+    @Column(name = "update_date")
+    private LocalDateTime updateDate;
+}

--- a/src/main/java/com/example/demo/model/TrustScore.java
+++ b/src/main/java/com/example/demo/model/TrustScore.java
@@ -17,7 +17,7 @@ public class TrustScore {
     @Column(name = "trust_score_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/com/example/demo/model/TrustScoreHistory.java
+++ b/src/main/java/com/example/demo/model/TrustScoreHistory.java
@@ -1,0 +1,45 @@
+package com.example.demo.model;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "trust_score_history")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TrustScoreHistory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "trust_score_history_id")
+    Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trust_score_type_id")
+    TrustScoreType trustScoreType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "milestone_id")
+    Milestone milestone;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "work_id")
+    Work work;
+
+    @Column(name = "score")
+    Long score;
+
+    @Column(name = "create_date")
+    LocalDateTime createDate;
+}

--- a/src/main/java/com/example/demo/model/TrustScoreHistory.java
+++ b/src/main/java/com/example/demo/model/TrustScoreHistory.java
@@ -3,6 +3,8 @@ package com.example.demo.model;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -10,6 +12,7 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "trust_score_history")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 public class TrustScoreHistory {
     @Id
@@ -40,6 +43,7 @@ public class TrustScoreHistory {
     @Column(name = "score")
     Long score;
 
-    @Column(name = "create_date")
+    @CreatedDate
+    @Column(name = "create_date", updatable = false)
     LocalDateTime createDate;
 }

--- a/src/main/java/com/example/demo/model/TrustScoreType.java
+++ b/src/main/java/com/example/demo/model/TrustScoreType.java
@@ -1,0 +1,39 @@
+package com.example.demo.model;
+
+import com.example.demo.constant.ScoreTypeDistinguishCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "trust_score_type")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TrustScoreType {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "trust_score_type_id")
+    Long id;
+
+    @Column(name = "name")
+    String name;
+
+    @Column(name = "score")
+    Long score;
+
+    @Column(name = "distinguish_code")
+    ScoreTypeDistinguishCode distinguishCode;
+
+    @ManyToOne
+    @JoinColumn(name = "trust_grade_id")
+    TrustGrade trustGrade;
+
+    @Column(name = "create_date")
+    LocalDateTime createDate;
+
+    @Column(name = "update_date")
+    LocalDateTime updateDate;
+}

--- a/src/main/java/com/example/demo/model/TrustScoreType.java
+++ b/src/main/java/com/example/demo/model/TrustScoreType.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @Table(name = "trust_score_type")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class TrustScoreType {
+public class TrustScoreType extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "trust_score_type_id")
@@ -34,10 +34,4 @@ public class TrustScoreType {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "trust_point_type_parent_id")
     TrustScoreType trustPointTypeParent;
-
-    @Column(name = "create_date")
-    LocalDateTime createDate;
-
-    @Column(name = "update_date")
-    LocalDateTime updateDate;
 }

--- a/src/main/java/com/example/demo/model/TrustScoreType.java
+++ b/src/main/java/com/example/demo/model/TrustScoreType.java
@@ -25,6 +25,7 @@ public class TrustScoreType extends BaseTimeEntity {
     Long score;
 
     @Column(name = "distinguish_code")
+    @Enumerated(EnumType.STRING)
     ScoreTypeDistinguishCode distinguishCode;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/demo/model/TrustScoreType.java
+++ b/src/main/java/com/example/demo/model/TrustScoreType.java
@@ -27,9 +27,13 @@ public class TrustScoreType {
     @Column(name = "distinguish_code")
     ScoreTypeDistinguishCode distinguishCode;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "trust_grade_id")
     TrustGrade trustGrade;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trust_point_type_parent_id")
+    TrustScoreType trustPointTypeParent;
 
     @Column(name = "create_date")
     LocalDateTime createDate;

--- a/src/main/java/com/example/demo/repository/TrustScoreHistoryRepository.java
+++ b/src/main/java/com/example/demo/repository/TrustScoreHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.example.demo.repository;
+
+import com.example.demo.model.TrustScoreHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TrustScoreHistoryRepository extends JpaRepository<TrustScoreHistory, Long>, TrustScoreHistoryRepositoryCustom {
+}

--- a/src/main/java/com/example/demo/repository/TrustScoreHistoryRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/TrustScoreHistoryRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.example.demo.repository;
+
+public interface TrustScoreHistoryRepositoryCustom {
+}

--- a/src/main/java/com/example/demo/repository/TrustScoreHistoryRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/TrustScoreHistoryRepositoryImpl.java
@@ -1,0 +1,4 @@
+package com.example.demo.repository;
+
+public class TrustScoreHistoryRepositoryImpl implements TrustScoreRepositoryCustom {
+}

--- a/src/main/java/com/example/demo/repository/TrustScoreRepository.java
+++ b/src/main/java/com/example/demo/repository/TrustScoreRepository.java
@@ -1,0 +1,7 @@
+package com.example.demo.repository;
+
+import com.example.demo.model.TrustScore;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TrustScoreRepository extends JpaRepository<TrustScore, Long>, TrustScoreRepositoryCustom {
+}

--- a/src/main/java/com/example/demo/repository/TrustScoreRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/TrustScoreRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.example.demo.repository;
+
+public interface TrustScoreRepositoryCustom {
+}

--- a/src/main/java/com/example/demo/repository/TrustScoreRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/TrustScoreRepositoryImpl.java
@@ -1,0 +1,4 @@
+package com.example.demo.repository;
+
+public class TrustScoreRepositoryImpl implements TrustScoreRepositoryCustom{
+}

--- a/src/main/java/com/example/demo/repository/TrustScoreTypeRepository.java
+++ b/src/main/java/com/example/demo/repository/TrustScoreTypeRepository.java
@@ -1,0 +1,8 @@
+package com.example.demo.repository;
+
+import com.example.demo.model.TrustScoreType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TrustScoreTypeRepository extends JpaRepository<TrustScoreType, Long>, TrustScoreTypeRepositoryCustom
+{
+}

--- a/src/main/java/com/example/demo/repository/TrustScoreTypeRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/TrustScoreTypeRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.example.demo.repository;
+
+public interface TrustScoreTypeRepositoryCustom {
+}

--- a/src/main/java/com/example/demo/repository/TrustScoreTypeRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/TrustScoreTypeRepositoryImpl.java
@@ -1,0 +1,4 @@
+package com.example.demo.repository;
+
+public class TrustScoreTypeRepositoryImpl implements TrustScoreTypeRepositoryCustom {
+}

--- a/src/main/java/com/example/demo/service/TrustScoreHistoryService.java
+++ b/src/main/java/com/example/demo/service/TrustScoreHistoryService.java
@@ -1,0 +1,4 @@
+package com.example.demo.service;
+
+public interface TrustScoreHistoryService {
+}

--- a/src/main/java/com/example/demo/service/TrustScoreHistoryServiceImpl.java
+++ b/src/main/java/com/example/demo/service/TrustScoreHistoryServiceImpl.java
@@ -1,0 +1,4 @@
+package com.example.demo.service;
+
+public class TrustScoreHistoryServiceImpl implements TrustScoreHistoryService {
+}

--- a/src/main/java/com/example/demo/service/TrustScoreHistoryServiceImpl.java
+++ b/src/main/java/com/example/demo/service/TrustScoreHistoryServiceImpl.java
@@ -1,4 +1,11 @@
 package com.example.demo.service;
 
+import com.example.demo.repository.TrustScoreHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class TrustScoreHistoryServiceImpl implements TrustScoreHistoryService {
+    private final TrustScoreHistoryRepository trustScoreHistoryRepository;
 }

--- a/src/main/java/com/example/demo/service/TrustScoreService.java
+++ b/src/main/java/com/example/demo/service/TrustScoreService.java
@@ -1,0 +1,4 @@
+package com.example.demo.service;
+
+public interface TrustScoreService {
+}

--- a/src/main/java/com/example/demo/service/TrustScoreServiceImpl.java
+++ b/src/main/java/com/example/demo/service/TrustScoreServiceImpl.java
@@ -1,0 +1,4 @@
+package com.example.demo.service;
+
+public class TrustScoreServiceImpl implements TrustScoreService{
+}

--- a/src/main/java/com/example/demo/service/TrustScoreServiceImpl.java
+++ b/src/main/java/com/example/demo/service/TrustScoreServiceImpl.java
@@ -1,4 +1,11 @@
 package com.example.demo.service;
 
+import com.example.demo.repository.TrustScoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class TrustScoreServiceImpl implements TrustScoreService{
+    private final TrustScoreRepository trustScoreRepository;
 }

--- a/src/main/java/com/example/demo/service/TrustScoreTypeService.java
+++ b/src/main/java/com/example/demo/service/TrustScoreTypeService.java
@@ -1,0 +1,4 @@
+package com.example.demo.service;
+
+public interface TrustScoreTypeService {
+}

--- a/src/main/java/com/example/demo/service/TrustScoreTypeServiceImpl.java
+++ b/src/main/java/com/example/demo/service/TrustScoreTypeServiceImpl.java
@@ -1,0 +1,4 @@
+package com.example.demo.service;
+
+public class TrustScoreTypeServiceImpl implements TrustScoreTypeService {
+}

--- a/src/main/java/com/example/demo/service/TrustScoreTypeServiceImpl.java
+++ b/src/main/java/com/example/demo/service/TrustScoreTypeServiceImpl.java
@@ -1,4 +1,11 @@
 package com.example.demo.service;
 
+import com.example.demo.repository.TrustScoreHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class TrustScoreTypeServiceImpl implements TrustScoreTypeService {
+    private final TrustScoreHistoryRepository trustScoreHistoryRepository;
 }


### PR DESCRIPTION
신뢰점수 도메인 관련 엔티티, 레이어, 도메인을 생성했습니다.
부차적으로, 패키지명 소문자화 그리고 BaseTimeEntity 조금 깔끔하게 손 보았습니다.