### PR TITLE
[feature/74-jwt] JWT 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,11 @@ repositories {
 }
 
 dependencies {
+	/* jwt */
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 	/* Redis */
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 

--- a/src/main/java/com/example/demo/global/exception/customexception/TokenCustomException.java
+++ b/src/main/java/com/example/demo/global/exception/customexception/TokenCustomException.java
@@ -1,0 +1,25 @@
+package com.example.demo.global.exception.customexception;
+
+import com.example.demo.global.exception.errorcode.TokenErrorCode;
+
+public class TokenCustomException extends CustomException{
+
+    public static final TokenCustomException NON_ACCESS_TOKEN =
+            new TokenCustomException(TokenErrorCode.NON_ACCESS_TOKEN);
+
+    public static final TokenCustomException WRONG_TYPE_SIGNATURE =
+            new TokenCustomException(TokenErrorCode.WRONG_TYPE_SIGNATURE);
+
+    public static final TokenCustomException WRONG_TYPE_TOKEN =
+            new TokenCustomException(TokenErrorCode.WRONG_TYPE_TOKEN);
+
+    public static final TokenCustomException EXPIRED_TOKEN =
+            new TokenCustomException(TokenErrorCode.EXPIRED_TOKEN);
+
+    public static final TokenCustomException MALFORMED_TOKEN =
+            new TokenCustomException(TokenErrorCode.MALFORMED_TOKEN);
+
+    public TokenCustomException(TokenErrorCode tokenErrorCode) {
+        super(tokenErrorCode);
+    }
+}

--- a/src/main/java/com/example/demo/global/exception/errorcode/TokenErrorCode.java
+++ b/src/main/java/com/example/demo/global/exception/errorcode/TokenErrorCode.java
@@ -1,0 +1,29 @@
+package com.example.demo.global.exception.errorcode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum TokenErrorCode implements ErrorCode{
+
+    NON_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "엑세스 토큰 정보가 존재하지 않습니다."),
+    WRONG_TYPE_SIGNATURE(HttpStatus.UNAUTHORIZED, "잘못된 JWT 시그니처입니다."),
+    WRONG_TYPE_TOKEN(HttpStatus.UNAUTHORIZED, "지원되지 않는 형식이나 구성의 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰 정보입니다."),
+    MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, "손상된 토큰 정보입니다.");
+
+    private HttpStatus status;
+    private String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return this.status;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/example/demo/security/jwt/JsonWebTokenDto.java
+++ b/src/main/java/com/example/demo/security/jwt/JsonWebTokenDto.java
@@ -1,0 +1,19 @@
+package com.example.demo.security.jwt;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class JsonWebTokenDto {
+
+    private String accessToken;
+    private String refreshToken;
+
+    public static JsonWebTokenDto of (String accessToken, String refreshToken) {
+        return JsonWebTokenDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/security/jwt/JsonWebTokenProvider.java
+++ b/src/main/java/com/example/demo/security/jwt/JsonWebTokenProvider.java
@@ -10,8 +10,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Calendar;
@@ -116,5 +118,25 @@ public class JsonWebTokenProvider {
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
+    }
+
+    // Request Header 에서 Access Token 정보 추출
+    public String resolveAccessToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if(StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken;
+        }
+
+        return null;
+    }
+
+    // Request Header 에서 Refresh Token 정보 추출
+    public String resolveRefreshToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(REFRESH_HEADER);
+        if(StringUtils.hasText(bearerToken)) {
+            return bearerToken;
+        }
+
+        return null;
     }
 }

--- a/src/main/java/com/example/demo/security/jwt/JsonWebTokenProvider.java
+++ b/src/main/java/com/example/demo/security/jwt/JsonWebTokenProvider.java
@@ -1,0 +1,50 @@
+package com.example.demo.security.jwt;
+
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.io.Encoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+
+@Slf4j
+@Component
+public class JsonWebTokenProvider {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String REFRESH_HEADER = "Refresh";
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    // public static final long ACCESS_TOKEN_EXPIRE_MILLIS_TEST = 1000 * 60; // 1분
+    public static final long ACCESS_TOKEN_EXPIRE_MILLIS = 1000 * 60 * 30; // 30분
+
+    // public static final long REFRESH_TOKEN_EXPIRE_MILLIS_TEST = 1000 * 60 * 2; // 2분
+    public static final long REFRESH_TOKEN_EXPIRE_MILLIS = 1000 * 60 * 60 * 24 * 7; // 7일
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    private Key key;
+
+    // key 초기화
+    @PostConstruct
+    public void init() {
+        String base64EncodedSecretKey = encodedBase64SecretKey(this.secretKey);
+        this.key = getKeyFromBase64EncodedKey(base64EncodedSecretKey);
+    }
+
+    // JWT Secret Key Base64 Encoded
+    private String encodedBase64SecretKey(String secretKey) {
+        return Encoders.BASE64.encode(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // Base64로 인코드된 Secret Key Decoded -> key 셋팅
+    private Key getKeyFromBase64EncodedKey(String base64EncodedSecretKey) {
+        byte[] keyBytes = Decoders.BASE64URL.decode(base64EncodedSecretKey);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+}

--- a/src/main/java/com/example/demo/security/jwt/JsonWebTokenProvider.java
+++ b/src/main/java/com/example/demo/security/jwt/JsonWebTokenProvider.java
@@ -1,11 +1,11 @@
 package com.example.demo.security.jwt;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import com.example.demo.global.exception.customexception.TokenCustomException;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.io.Encoders;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -89,5 +89,32 @@ public class JsonWebTokenProvider {
     private Date getTokenExpiration(long expirationMillisecond) {
         Date date = new Date();
         return new Date(date.getTime() + expirationMillisecond);
+    }
+
+    // 토큰 검증
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (MalformedJwtException e) {
+            throw TokenCustomException.MALFORMED_TOKEN;
+        } catch (UnsupportedJwtException e) {
+            throw TokenCustomException.WRONG_TYPE_TOKEN;
+        } catch (SignatureException e) {
+            throw TokenCustomException.WRONG_TYPE_SIGNATURE;
+        } catch (ExpiredJwtException e) {
+            throw TokenCustomException.EXPIRED_TOKEN;
+        } catch (IllegalArgumentException e) {
+            throw TokenCustomException.NON_ACCESS_TOKEN;
+        }
+    }
+
+    // 토큰 복호화
+    private Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(this.key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,3 +33,5 @@ spring.jpa.properties.hibernate.format_sql = true
 spring.redis.host=localhost
 spring.redis.port=6379
 
+# jwt
+jwt.secret=${jwt_secret_key}


### PR DESCRIPTION
### 작업내용
- JWT를 사용하기 위한 초기 셋팅 (의존성 추가, secret key 설정)
- JWT 로직을 담당하는 JsonWebTokenProvider 클래스 생성
- JsonWebTokenProvider에 토큰 발급, 토큰 검증, 토큰 추출 로직 구현
- Access Token과 Refresh Token을 함께 관리하는 JsonWebTokenDto 생성