### PR TITLE
[feature/74-refresh-token-service] RefreshToken CRD 구현

### DIFF
--- a/src/main/java/com/example/demo/service/token/RefreshTokenRedisService.java
+++ b/src/main/java/com/example/demo/service/token/RefreshTokenRedisService.java
@@ -1,0 +1,23 @@
+package com.example.demo.service.token;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenRedisService {
+
+    private static final String KEY_PREFIX = "refreshToken:";
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Value("${jwt.refresh.token.expiration.millis}")
+    private long refreshTokenExpiresMillis;
+
+}

--- a/src/main/java/com/example/demo/service/token/RefreshTokenRedisService.java
+++ b/src/main/java/com/example/demo/service/token/RefreshTokenRedisService.java
@@ -33,4 +33,13 @@ public class RefreshTokenRedisService {
         String key = KEY_PREFIX + userId;
         return Optional.ofNullable(redisTemplate.opsForValue().get(key)).orElse(null);
     }
+
+    // Refresh Token 삭제
+    public void delete(Long userId) {
+        String key = KEY_PREFIX + userId;
+
+        if(redisTemplate.hasKey(key)) {
+            redisTemplate.delete(key);
+        }
+    }
 }

--- a/src/main/java/com/example/demo/service/token/RefreshTokenRedisService.java
+++ b/src/main/java/com/example/demo/service/token/RefreshTokenRedisService.java
@@ -20,4 +20,11 @@ public class RefreshTokenRedisService {
     @Value("${jwt.refresh.token.expiration.millis}")
     private long refreshTokenExpiresMillis;
 
+    // Refresh Token 저장 (만료시간도 함께 설정)
+    public void save(final Long userId, final String refreshToken) {
+        String key = KEY_PREFIX + userId;
+
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set(key, refreshToken, refreshTokenExpiresMillis, TimeUnit.MILLISECONDS);
+    }
 }

--- a/src/main/java/com/example/demo/service/token/RefreshTokenRedisService.java
+++ b/src/main/java/com/example/demo/service/token/RefreshTokenRedisService.java
@@ -27,4 +27,10 @@ public class RefreshTokenRedisService {
         ValueOperations<String, String> values = redisTemplate.opsForValue();
         values.set(key, refreshToken, refreshTokenExpiresMillis, TimeUnit.MILLISECONDS);
     }
+
+    // Refresh Token 조회
+    public String get(final Long userId) {
+        String key = KEY_PREFIX + userId;
+        return Optional.ofNullable(redisTemplate.opsForValue().get(key)).orElse(null);
+    }
 }


### PR DESCRIPTION
### 작업내용
- Redis로 RefreshToken을 관리하기 위한 RefreshTokenRedisService 생성
- RefreshToken을 저장하는 save() 로직 구현, Redis에 key="refreshToken:회원PK", value="refreshToken" 형태로 저장하도록 구현
- RefreshToken을 조회하는 get() 로직 구현
- RefreshToken을 삭제하는 delete() 로직 구현
- RTR(Refresh Token Rotation) 기법을 사용하고자 RefreshToken을 수정하는 로직은 구현하지 않음