### PR TITLE
[feature/74-fix-jwt-provider] JWT Provider 수정

### DIFF
--- a/src/main/java/com/example/demo/global/exception/customexception/TokenCustomException.java
+++ b/src/main/java/com/example/demo/global/exception/customexception/TokenCustomException.java
@@ -19,6 +19,9 @@ public class TokenCustomException extends CustomException{
     public static final TokenCustomException MALFORMED_TOKEN =
             new TokenCustomException(TokenErrorCode.MALFORMED_TOKEN);
 
+    public static final TokenCustomException DOES_NOT_REFRESH_TOKEN =
+            new TokenCustomException(TokenErrorCode.DOES_NOT_REFRESH_TOKEN);
+
     public TokenCustomException(TokenErrorCode tokenErrorCode) {
         super(tokenErrorCode);
     }

--- a/src/main/java/com/example/demo/global/exception/errorcode/TokenErrorCode.java
+++ b/src/main/java/com/example/demo/global/exception/errorcode/TokenErrorCode.java
@@ -12,7 +12,8 @@ public enum TokenErrorCode implements ErrorCode{
     WRONG_TYPE_SIGNATURE(HttpStatus.UNAUTHORIZED, "잘못된 JWT 시그니처입니다."),
     WRONG_TYPE_TOKEN(HttpStatus.UNAUTHORIZED, "지원되지 않는 형식이나 구성의 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰 정보입니다."),
-    MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, "손상된 토큰 정보입니다.");
+    MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, "손상된 토큰 정보입니다."),
+    DOES_NOT_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "요청 헤더 쿠키에 리프레시 토큰 정보가 존재하지 않습니다.");
 
     private HttpStatus status;
     private String message;

--- a/src/main/java/com/example/demo/security/jwt/JsonWebTokenProvider.java
+++ b/src/main/java/com/example/demo/security/jwt/JsonWebTokenProvider.java
@@ -64,6 +64,8 @@ public class JsonWebTokenProvider {
         Date accessTokenExpiresIn = getTokenExpiration(accessTokenExpirationMillis);
 
         Claims claims = Jwts.claims().setSubject(principalDetails.getUsername());
+        claims.put("email", principalDetails.getEmail());
+        claims.put("nickname", principalDetails.getNickname());
         claims.put("role", principalDetails.getAuthorities());
 
         String accessToken = Jwts.builder()

--- a/src/main/java/com/example/demo/security/jwt/JsonWebTokenProvider.java
+++ b/src/main/java/com/example/demo/security/jwt/JsonWebTokenProvider.java
@@ -1,6 +1,7 @@
 package com.example.demo.security.jwt;
 
 import com.example.demo.global.exception.customexception.TokenCustomException;
+import com.example.demo.security.custom.PrincipalDetails;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.io.Encoders;
@@ -57,13 +58,13 @@ public class JsonWebTokenProvider {
     }
 
     // 토큰 발급 (Access Token & Refresh Token 함께 발급)
-    public JsonWebTokenDto generateToken(UserDetails userDetails) {
+    public JsonWebTokenDto generateToken(PrincipalDetails principalDetails) {
 
         // Access Token 생성
         Date accessTokenExpiresIn = getTokenExpiration(accessTokenExpirationMillis);
 
-        Claims claims = Jwts.claims().setSubject(userDetails.getUsername());
-        claims.put("role", userDetails.getAuthorities());
+        Claims claims = Jwts.claims().setSubject(principalDetails.getUsername());
+        claims.put("role", principalDetails.getAuthorities());
 
         String accessToken = Jwts.builder()
                 .setClaims(claims)

--- a/src/main/java/com/example/demo/security/jwt/JsonWebTokenProvider.java
+++ b/src/main/java/com/example/demo/security/jwt/JsonWebTokenProvider.java
@@ -14,9 +14,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 import javax.annotation.PostConstruct;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -135,7 +137,13 @@ public class JsonWebTokenProvider {
 
     // Request Header 에서 Refresh Token 정보 추출
     public String resolveRefreshToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader(REFRESH_HEADER);
+        Cookie[] cookies = request.getCookies();
+        String bearerToken = Arrays.stream(cookies)
+                .filter(cookie -> cookie.getName().equals(REFRESH_HEADER))
+                .findFirst()
+                .orElseThrow(() -> TokenCustomException.DOES_NOT_REFRESH_TOKEN)
+                .getValue();
+
         if(StringUtils.hasText(bearerToken)) {
             return bearerToken;
         }


### PR DESCRIPTION
### 작업내용
- 토큰을 발급하는 로직 generateToken()의 파라미터 타입을 UserDetails -> PrincipalDetails로 변경
- AccessToken을 발급하는 과정에서 claims에 이메일과 닉네임 값을 추가로 셋팅해 발급받을 수 있도록 수정
- RefreshToken을 추출하는 로직 resolveRefreshToken()을 요청 헤더의 쿠키로부터 값을 추출하는 로직으로 변경
- 요청 헤더 쿠키에 RefreshToken 값이 존재하지 않을 경우의 에러코드, 커스텀 예외 추가