### PR TITLE
[feature/74-security-jwt-authorization] JWT 검증 및 인가 로직 구현

### DIFF
--- a/src/main/java/com/example/demo/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.example.demo.global.config;
 
 import com.example.demo.security.custom.UserAuthenticationFilter;
+import com.example.demo.security.jwt.JsonWebTokenAuthorizationFilter;
 import com.example.demo.security.jwt.JsonWebTokenProvider;
 import com.example.demo.service.token.RefreshTokenRedisService;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Slf4j
 @Configuration
@@ -45,19 +47,17 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        return http.csrf()
-                .disable()
+        return http.csrf().disable()
                 .cors()
                 .and()
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
-                .formLogin()
-                .disable()
-                .httpBasic()
-                .disable()
+                .formLogin().disable()
+                .httpBasic().disable()
                 .apply(new UserAuthenticationFilterConfigurer())
                 .and()
+                .addFilterBefore(new JsonWebTokenAuthorizationFilter(jsonWebTokenProvider), UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 

--- a/src/main/java/com/example/demo/security/jwt/JsonWebTokenAuthorizationFilter.java
+++ b/src/main/java/com/example/demo/security/jwt/JsonWebTokenAuthorizationFilter.java
@@ -27,6 +27,7 @@ public class JsonWebTokenAuthorizationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String requestUri = request.getRequestURI();
         String accessToken = jsonWebTokenProvider.resolveAccessToken(request);
+        log.info("AccessToken : {}", accessToken);
 
         // 요청 URI 확인 및 토큰 검증
         if(!PERMIT_URI.contains(requestUri) && jsonWebTokenProvider.validateToken(accessToken)) {

--- a/src/main/java/com/example/demo/security/jwt/JsonWebTokenAuthorizationFilter.java
+++ b/src/main/java/com/example/demo/security/jwt/JsonWebTokenAuthorizationFilter.java
@@ -1,6 +1,8 @@
 package com.example.demo.security.jwt;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
@@ -8,12 +10,33 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
 
 // JWT 검증하고 인가를 처리하는 필터
 @Slf4j
 public class JsonWebTokenAuthorizationFilter extends OncePerRequestFilter {
+
+    private static final List<String> PERMIT_URI = List.of("/api/user/login");
+    private JsonWebTokenProvider jsonWebTokenProvider;
+
+    public JsonWebTokenAuthorizationFilter(JsonWebTokenProvider jsonWebTokenProvider) {
+        this.jsonWebTokenProvider = jsonWebTokenProvider;
+    }
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String requestUri = request.getRequestURI();
+        String accessToken = jsonWebTokenProvider.resolveAccessToken(request);
 
+        // 요청 URI 확인 및 토큰 검증
+        if(!PERMIT_URI.contains(requestUri) && jsonWebTokenProvider.validateToken(accessToken)) {
+            // 토큰에 담긴 회원정보를 추출해 시큐리티에서 사용할 인증 객체 반환
+            Authentication authentication = jsonWebTokenProvider.getAuthentication(accessToken);
+
+            // 시큐리티 컨텍스트 홀더에 사용자 인증 객체를 셋팅
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/com/example/demo/security/jwt/JsonWebTokenAuthorizationFilter.java
+++ b/src/main/java/com/example/demo/security/jwt/JsonWebTokenAuthorizationFilter.java
@@ -1,0 +1,19 @@
+package com.example.demo.security.jwt;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+// JWT 검증하고 인가를 처리하는 필터
+@Slf4j
+public class JsonWebTokenAuthorizationFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+    }
+}

--- a/src/main/java/com/example/demo/security/jwt/JsonWebTokenProvider.java
+++ b/src/main/java/com/example/demo/security/jwt/JsonWebTokenProvider.java
@@ -9,6 +9,8 @@ import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SignatureException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -114,6 +116,19 @@ public class JsonWebTokenProvider {
         } catch (IllegalArgumentException e) {
             throw TokenCustomException.NON_ACCESS_TOKEN;
         }
+    }
+
+    // 토큰에서 회원정보를 추출해 사용자 인증 Authentication 객체로 반환
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseClaims(token);
+
+        String email = String.valueOf(claims.get("email"));
+        String nickname = String.valueOf(claims.get("nickname"));
+        String authority = String.valueOf(claims.get("role"));
+
+        PrincipalDetails principalDetails = PrincipalDetails.of(claims.getSubject(), email, nickname, authority);
+
+        return new UsernamePasswordAuthenticationToken(principalDetails, "", principalDetails.getAuthorities());
     }
 
     // 토큰 복호화


### PR DESCRIPTION
### 작업내용
- JWT 검증 및 인가과정을 처리하는 JsonWebTokenAuthorizationFilter 구현
- 검증이 완료된 AccessToken에서 회원정보를 추출하여 시큐리티 사용자 인증 객체로 반환하는 로직 구현
- 인증 및 인가과정이 필요하지 않는 로직 중 "/api/user/login" 요청은 따로 동작하는 필터가 있어 해당 요청을 JsonWebTokenAuthorizationFilter 내에서 처리할 수 있도록 구현 (SecurityConfig의 configue(), filterChain()에서 처리하면 필터가 모든 요청에서 동작하는 이슈 발생)