### PR TITLE
[feature/74-fix-jwt-resolve-access-token] 요청 헤더에서 AccessToken 값 가져오는 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/security/jwt/JsonWebTokenProvider.java
+++ b/src/main/java/com/example/demo/security/jwt/JsonWebTokenProvider.java
@@ -144,7 +144,7 @@ public class JsonWebTokenProvider {
     public String resolveAccessToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
         if(StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
-            return bearerToken;
+            return bearerToken.substring(7);
         }
 
         return null;


### PR DESCRIPTION
### 작업내용
- JsonWebTokenProvider의 resolveAccessToken() 메소드 로직 수정
- Access Token 디코드 에러 이슈로 Access Token 값을 return 하는 코드에 .subString(7) 코드 추가해서 해결