### PR TITLE
[feature/74-fix-user-entity] 회원 엔티티 수정

### DIFF
--- a/src/main/java/com/example/demo/dto/user/response/UserCrewDetailResponseDto.java
+++ b/src/main/java/com/example/demo/dto/user/response/UserCrewDetailResponseDto.java
@@ -27,7 +27,7 @@ public class UserCrewDetailResponseDto {
     private LocalDateTime createDate;
     private LocalDateTime updateDate;
 
-    public static UserCrewDetailResponseDto of(User user, PositionResponseDto position, TrustGradeResponseDto trustGrade, List<TechnologyStackInfoResponseDto> technologyStacks) {
+    public static UserCrewDetailResponseDto of(User user, int trustScore, PositionResponseDto position, TrustGradeResponseDto trustGrade, List<TechnologyStackInfoResponseDto> technologyStacks) {
         return UserCrewDetailResponseDto.builder()
                 .userId(user.getId())
                 .email(user.getEmail())
@@ -35,7 +35,7 @@ public class UserCrewDetailResponseDto {
                 .profileImgSrc(user.getProfileImgSrc())
                 .position(position)
                 .trustGrade(trustGrade)
-                .trustScore(user.getTrustScore())
+                .trustScore(trustScore)
                 .role(user.getRole())
                 .intro(user.getIntro())
                 .technologyStacks(technologyStacks)

--- a/src/main/java/com/example/demo/model/user/User.java
+++ b/src/main/java/com/example/demo/model/user/User.java
@@ -36,12 +36,6 @@ public class User extends BaseTimeEntity {
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     private List<UserTechnologyStack> techStacks;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "trust_grade_id")
-    private TrustGrade trustGrade;
-
-    private int trustScore;
-
     @Enumerated(EnumType.STRING)
     private Role role;
 
@@ -53,9 +47,6 @@ public class User extends BaseTimeEntity {
             String profileImgSrc,
             String intro,
             Position position,
-            List<UserTechnologyStack> techStacks,
-            TrustGrade trustGrade,
-            int trustScore,
             Role role) {
         this.email = email;
         this.password = password;
@@ -64,8 +55,11 @@ public class User extends BaseTimeEntity {
         this.intro = intro;
         this.position = position;
         this.techStacks = techStacks;
-        this.trustGrade = trustGrade;
-        this.trustScore = trustScore;
         this.role = role;
+    }
+
+    // 기술스택 목록 등록
+    public void setTechStacks(List<UserTechnologyStack> techStacks) {
+        this.techStacks = techStacks;
     }
 }

--- a/src/main/java/com/example/demo/repository/board/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/example/demo/repository/board/BoardRepositoryCustomImpl.java
@@ -19,6 +19,7 @@ import com.example.demo.model.project.QProject;
 import com.example.demo.model.project.QProjectTechnology;
 import com.example.demo.model.technology_stack.QTechnologyStack;
 import com.example.demo.model.technology_stack.TechnologyStack;
+import com.example.demo.model.trust_grade.TrustGrade;
 import com.example.demo.model.user.QUser;
 import com.example.demo.model.user.User;
 import com.example.demo.repository.position.PositionRepository;
@@ -123,7 +124,9 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom {
             ProjectSearchResponseDto projectSearchResponseDto = ProjectSearchResponseDto.of(project, projectTrustGradeResponseDto, technologyStacks);
 
             User user = boardEntity.getUser();
-            TrustGradeResponseDto userTrustGradeResponseDto = TrustGradeResponseDto.of(user.getTrustGrade());
+
+            // 임시수정
+            TrustGradeResponseDto userTrustGradeResponseDto = TrustGradeResponseDto.of(null);
             UserSearchResponseDto userSearchResponseDto = UserSearchResponseDto.of(user, userTrustGradeResponseDto);
 
             boardSearchResponseDtos.add(BoardSearchResponseDto.of(boardEntity, projectSearchResponseDto,userSearchResponseDto));

--- a/src/main/java/com/example/demo/service/project/ProjectMemberFacade.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberFacade.java
@@ -71,7 +71,8 @@ public class ProjectMemberFacade {
             technologyStackInfoResponseDtoList.add(technologyStackInfoResponseDto);
         }
 
-        UserCrewDetailResponseDto userCrewDetailResponseDto = UserCrewDetailResponseDto.of(projectMember.getUser(),positionResponseDto, trustGradeResponseDto, technologyStackInfoResponseDtoList);
+        // 임시
+        UserCrewDetailResponseDto userCrewDetailResponseDto = UserCrewDetailResponseDto.of(projectMember.getUser(),1,positionResponseDto, trustGradeResponseDto, technologyStackInfoResponseDtoList);
 
         return ProjectMemberReadCrewDetailResponseDto.of(
                 projectMember,


### PR DESCRIPTION
### 작업내용
- 신뢰점수, 신뢰등급 필드 삭제 (추후 변경가능 있음)
- 회원의 기술스택목록을 등록하는 메소드 생성
- 회원 엔티티를 수정함에 따라 관련 코드 임시 수정(UserCrewDetailResponseDto of(), BoardRepositoryCustomImpl getBoardSearchPage(), BoardFacade getCrewDetail())