### PR TITLE
[feature/fix-validation-exception] @Valid 유효성 검증 예외 발생 시 버그 해결

### DIFF
--- a/src/main/java/com/example/demo/global/exception/CustomFieldError.java
+++ b/src/main/java/com/example/demo/global/exception/CustomFieldError.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.validation.FieldError;
 
+import java.util.Objects;
+
 @Getter
 @AllArgsConstructor
 public class CustomFieldError {
@@ -14,7 +16,7 @@ public class CustomFieldError {
 
     public CustomFieldError(FieldError fieldError) {
         this.field = fieldError.getField();
-        this.invalidValue = fieldError.getRejectedValue().toString();
+        this.invalidValue = fieldError.getRejectedValue() != null ? fieldError.getRejectedValue().toString() : null;
         this.reason = fieldError.getDefaultMessage();
     }
 }

--- a/src/main/java/com/example/demo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/demo/global/exception/GlobalExceptionHandler.java
@@ -23,7 +23,7 @@ public class GlobalExceptionHandler {
                         .map(CustomFieldError::new)
                         .collect(Collectors.toList());
 
-        final ResponseDto<List<CustomFieldError>> response = ResponseDto.fail("", errors);
+        final ResponseDto<List<CustomFieldError>> response = ResponseDto.fail("데이터 유효성 검사에 실패했습니다.", errors);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 


### PR DESCRIPTION
### 작업내용
- @Valid 어노테이션으로 데이터 유효성을 검증할 때 예외 발생 시 @ExceptionHandler에서 예외를 잡아 처리하는데 요청 시 필요 데이터를 누락해 보낸 경우 FieldError 타입 객체의 getRejectedValue() 메소드에서 null 값을 참조해 NullPointException이 발생하는 버그 해결
- CustomFieldError 클래스 생성자로 null 체크를 통해 각 처리하도록 수정
- GlobalExceptionHandler의 @Valid Exception을 처리하는 메소드의 응답 값 중 메시지 내용 추가