### PR TITLE
[feature/163-user-logout] 로그아웃 로직 구현

### DIFF
--- a/src/main/java/com/example/demo/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.demo.global.config;
 
+import com.example.demo.security.jwt.JsonWebTokenLogoutFilter;
 import com.example.demo.security.jwt.JsonWebTokenExceptionFilter;
 import com.example.demo.security.custom.UserAuthenticationFailureHandler;
 import com.example.demo.security.custom.UserAuthenticationFilter;
@@ -26,7 +27,7 @@ import org.springframework.security.web.authentication.logout.LogoutFilter;
 
 @Slf4j
 @Configuration
-@EnableWebSecurity
+@EnableWebSecurity(debug = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -78,7 +79,8 @@ public class SecurityConfig {
                 .disable();
 
         http.addFilterAfter(userAuthenticationFilter(), LogoutFilter.class);
-        http.addFilterBefore(new JsonWebTokenAuthenticationFilter(jsonWebTokenProvider), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(new JsonWebTokenLogoutFilter(refreshTokenRedisService, objectMapper), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(new JsonWebTokenAuthenticationFilter(jsonWebTokenProvider), JsonWebTokenLogoutFilter.class);
         http.addFilterBefore(new JsonWebTokenExceptionFilter(objectMapper), JsonWebTokenAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/example/demo/security/jwt/JsonWebTokenLogoutFilter.java
+++ b/src/main/java/com/example/demo/security/jwt/JsonWebTokenLogoutFilter.java
@@ -1,0 +1,95 @@
+package com.example.demo.security.jwt;
+
+import com.example.demo.dto.common.ResponseDto;
+import com.example.demo.security.custom.PrincipalDetails;
+import com.example.demo.service.token.RefreshTokenRedisService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ *  로그아웃을 담당하는 커스텀 필터
+ *  로그아웃 로직도 로그인 된 상태에서 실행되어야 하므로, JsonWebTokenLogoutFilter 동작 전에 JsonWebTokenAuthenticationFilter 동작을 통해
+ *  사용자 인증 과정 후 로그아웃 로직을 실행할 수 있음
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class JsonWebTokenLogoutFilter extends OncePerRequestFilter {
+
+    private static final String DEFAULT_LOGOUT_REQUEST_URI = "/api/user/logout";
+
+    private final RefreshTokenRedisService refreshTokenRedisService;
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        // 로그아웃 요청이 아닐 경우, 다음 필터체인 수행
+        if(!isLogoutRequest(request)) {
+            filterChain.doFilter(request, response);
+        }
+
+        // 로그아웃 로직 수행
+        handleLogout(response);
+    }
+
+    // 로그아웃 요청 확인
+    private boolean isLogoutRequest(HttpServletRequest request) {
+        return request.getServletPath().equals(DEFAULT_LOGOUT_REQUEST_URI) &&
+                request.getMethod().equals(HttpMethod.POST.name());
+    }
+
+    // 로그아웃 로직 수행
+    private void handleLogout(HttpServletResponse response) throws IOException {
+        // 시큐리티 컨텍스트에서 사용자 인증 정보 가져오기
+        PrincipalDetails principalDetails = (PrincipalDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        log.info("user_id : {}", principalDetails.getId());
+
+        // RefreshToken 삭제
+        deleteRefreshToken(principalDetails.getId());
+
+        // 현재 사용자의 인증 정보 삭제
+        SecurityContextHolder.clearContext();
+
+        // 쿠키에서 RefreshToken 삭제
+        expirationRefreshCookie(response);
+
+        // 로그아웃 성공 응답
+        sendLogoutResponse(response);
+    }
+
+    // Redis 에서 회원의 RefreshToken 삭제
+    private void deleteRefreshToken(Long userId) {
+        if(refreshTokenRedisService.get(userId) != null) {
+            refreshTokenRedisService.delete(userId);
+        }
+    }
+
+    // Refresh Cookie 만료시키기
+    private void expirationRefreshCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie("Refresh", null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+    }
+
+    // 로그아웃 응답 설정
+    private void sendLogoutResponse(HttpServletResponse response) throws IOException{
+        response.setStatus(HttpStatus.OK.value());
+        response.setCharacterEncoding("utf-8");
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write(objectMapper.writeValueAsString(ResponseDto.success("로그아웃이 완료되었습니다.")));
+    }
+}


### PR DESCRIPTION
### 작업내용
- 로그아웃 요청 시 동작하는 JsonWebTokenLogoutFilter 구현
- 시큐리티 필터체인에 등록하여 로그아웃 요청인 경우에만 JsonWebTokenLogoutFilter가 동작하도록 구현
- 시큐리티 컨텍스트에 저장되어 있는 현재 회원의 인증 정보 객체를 가져와 회원의 RefreshToken을 Redis에서 삭제하고, SecurityContextHolder.clearContext()를 통해 저장된 회원의 인증 정보를 삭제한 후 Response 객체에 RefreshToken 관련 쿠키를 초기화 시켜 응답하도록 로직 구현


### 연관이슈
#163 