### PR TITLE
[feature/163-security-filter-common-response] 시큐리티 필터단의 응답 처리를 공통으로 관리하기 위한 클래스 구현

### DIFF
--- a/src/main/java/com/example/demo/security/SecurityResponseHandler.java
+++ b/src/main/java/com/example/demo/security/SecurityResponseHandler.java
@@ -1,0 +1,34 @@
+package com.example.demo.security;
+
+import com.example.demo.dto.common.ResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ *  시큐리티 필터단에서 응답할 때, 공통으로 관리하기 위한 클래스
+ */
+@Component
+@RequiredArgsConstructor
+public class SecurityResponseHandler {
+
+    private final ObjectMapper objectMapper;
+
+    // ResponseEntity 생성 및 반환
+    public void sendResponse(HttpServletResponse response, HttpStatus httpStatus, ResponseDto responseValue) throws IOException {
+        // 상태코드 설정
+        response.setStatus(httpStatus.value());
+        // 인코딩 타입 설정
+        response.setCharacterEncoding("utf-8");
+        // 컨텐트 타입 설정
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        // 클라이언트로 응답 객체 전송
+        response.getWriter().write(objectMapper.writeValueAsString(responseValue));
+    }
+}


### PR DESCRIPTION
### 작업내용
- 시큐리티 필터단에서 응답 처리를 공통으로 관리하기 위해 SecurityResponseHandler 클래스 구현
- SecurityResponseHandler 클래스를 스프링 빈으로 등록해 관리하고 sendResponse() 메소드를 통해 ResponseEntity를 생성하고 클라이언트에게 응답 객체를 전송하는 로직 구현


### 연관이슈
#163 