### PR TITLE
[feature/163-fix-security-filter-response] 시큐리티 필터 응답 처리 수정

### DIFF
--- a/src/main/java/com/example/demo/security/custom/UserAuthenticationFailureHandler.java
+++ b/src/main/java/com/example/demo/security/custom/UserAuthenticationFailureHandler.java
@@ -22,23 +22,13 @@ public class UserAuthenticationFailureHandler extends SimpleUrlAuthenticationFai
     // 회원 인증 실패 시 응답 할 커스텀 ErrorCode
     private static final UserErrorCode INVALID_AUTHENTICATION = UserErrorCode.INVALID_AUTHENTICATION;
 
-    private final ObjectMapper objectMapper;
-
-    public UserAuthenticationFailureHandler(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
-
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
                                         AuthenticationException exception) throws IOException {
         // ResponseDto<> 타입 응답 셋팅
         ResponseDto<Void> failureResponse = ResponseDto.fail(INVALID_AUTHENTICATION.getMessage());
 
-        // 로그인 실패 ResponseEntity 응답 생성 및 반환
-        response.setStatus(INVALID_AUTHENTICATION.getStatus().value());
-        response.setCharacterEncoding("UTF-8");
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.getWriter().write(objectMapper.writeValueAsString(failureResponse));
+
     }
 
 }

--- a/src/main/java/com/example/demo/security/custom/UserAuthenticationFailureHandler.java
+++ b/src/main/java/com/example/demo/security/custom/UserAuthenticationFailureHandler.java
@@ -2,7 +2,9 @@ package com.example.demo.security.custom;
 
 import com.example.demo.dto.common.ResponseDto;
 import com.example.demo.global.exception.errorcode.UserErrorCode;
+import com.example.demo.security.SecurityResponseHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
@@ -17,18 +19,18 @@ import java.io.IOException;
  *  UsernameNotFoundException OR BadCredentialsException 발생 시 커스텀 예외를 응답
  */
 @Slf4j
+@RequiredArgsConstructor
 public class UserAuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
     // 회원 인증 실패 시 응답 할 커스텀 ErrorCode
     private static final UserErrorCode INVALID_AUTHENTICATION = UserErrorCode.INVALID_AUTHENTICATION;
+    private final SecurityResponseHandler securityResponseHandler;
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
                                         AuthenticationException exception) throws IOException {
-        // ResponseDto<> 타입 응답 셋팅
-        ResponseDto<Void> failureResponse = ResponseDto.fail(INVALID_AUTHENTICATION.getMessage());
-
-
+        // 클라이언트로 응답 전송
+        securityResponseHandler.sendResponse(response, INVALID_AUTHENTICATION.getStatus(), ResponseDto.fail(INVALID_AUTHENTICATION.getMessage()));
     }
 
 }

--- a/src/main/java/com/example/demo/security/custom/UserAuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/demo/security/custom/UserAuthenticationSuccessHandler.java
@@ -2,12 +2,14 @@ package com.example.demo.security.custom;
 
 import com.example.demo.dto.common.ResponseDto;
 import com.example.demo.dto.user.response.UserLoginSuccessResponseDto;
+import com.example.demo.security.SecurityResponseHandler;
 import com.example.demo.security.jwt.JsonWebTokenDto;
 import com.example.demo.security.jwt.JsonWebTokenProvider;
 import com.example.demo.service.token.RefreshTokenRedisService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -28,6 +30,7 @@ public class UserAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuc
 
     private final JsonWebTokenProvider jsonWebTokenProvider;
     private final RefreshTokenRedisService refreshTokenRedisService;
+    private final SecurityResponseHandler securityResponseHandler;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -45,8 +48,11 @@ public class UserAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuc
         // Redis RefreshToken 저장
         refreshTokenRedisService.save(principalDetails.getId(), tokens.getRefreshToken());
 
-        // 로그인 성공 응답
+        // 로그인 성공 반환 데이터 셋팅
+        UserLoginSuccessResponseDto loginSuccessResponse = UserLoginSuccessResponseDto.of(principalDetails.getId(), principalDetails.getEmail(), principalDetails.getNickname(), principalDetails.getProfileImgSrc());
 
+        // 클라이언트로 응답 전송
+        securityResponseHandler.sendResponse(response, HttpStatus.OK, ResponseDto.success("로그인이 완료되었습니다.", loginSuccessResponse));
     }
 
     // RefreshToken 쿠키 생성

--- a/src/main/java/com/example/demo/security/custom/UserAuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/demo/security/custom/UserAuthenticationSuccessHandler.java
@@ -28,7 +28,6 @@ public class UserAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuc
 
     private final JsonWebTokenProvider jsonWebTokenProvider;
     private final RefreshTokenRedisService refreshTokenRedisService;
-    private final ObjectMapper objectMapper;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -47,7 +46,7 @@ public class UserAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuc
         refreshTokenRedisService.save(principalDetails.getId(), tokens.getRefreshToken());
 
         // 로그인 성공 응답
-        setSuccessLoginResponse(response, principalDetails);
+
     }
 
     // RefreshToken 쿠키 생성
@@ -57,26 +56,5 @@ public class UserAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuc
         cookie.setPath("/");
 
         return cookie;
-    }
-
-    // 로그인 성공 응답
-    private void setSuccessLoginResponse(HttpServletResponse response, PrincipalDetails principalDetails) throws IOException {
-        // UserLoginSuccessResponseDto 셋팅
-        UserLoginSuccessResponseDto loginSuccessResponseDto =
-                UserLoginSuccessResponseDto.builder()
-                        .userId(principalDetails.getId())
-                        .email(principalDetails.getEmail())
-                        .nickname(principalDetails.getNickname())
-                        .profileImgSrc(principalDetails.getProfileImgSrc())
-                        .build();
-
-        // ResponseDto<> 타입 응답 셋팅
-        ResponseDto<UserLoginSuccessResponseDto> successResponse =
-                ResponseDto.success("로그인에 성공하였습니다.", loginSuccessResponseDto);
-
-        // 로그인 성공 ResponseEntity 응답 생성 및 반환
-        response.setCharacterEncoding("UTF-8");
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.getWriter().write(objectMapper.writeValueAsString(successResponse));
     }
 }

--- a/src/main/java/com/example/demo/security/jwt/JsonWebTokenExceptionFilter.java
+++ b/src/main/java/com/example/demo/security/jwt/JsonWebTokenExceptionFilter.java
@@ -24,23 +24,12 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class JsonWebTokenExceptionFilter extends OncePerRequestFilter {
 
-    private final ObjectMapper objectMapper;
-
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
             filterChain.doFilter(request, response);
         } catch (TokenCustomException TokenCustomException) {
-            setExceptionResponse(response, TokenCustomException.getErrorCode());
-        }
-    }
 
-    // JWT 예외 응답 셋팅 및 반환
-    private void setExceptionResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
-        String exceptionResponse = objectMapper.writeValueAsString(ResponseDto.fail(errorCode.getMessage()));
-        response.setStatus(errorCode.getStatus().value());
-        response.setCharacterEncoding("UTF-8");
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.getWriter().write(exceptionResponse);
+        }
     }
 }

--- a/src/main/java/com/example/demo/security/jwt/JsonWebTokenExceptionFilter.java
+++ b/src/main/java/com/example/demo/security/jwt/JsonWebTokenExceptionFilter.java
@@ -4,6 +4,7 @@ import com.example.demo.dto.common.ResponseDto;
 import com.example.demo.global.exception.customexception.CustomException;
 import com.example.demo.global.exception.customexception.TokenCustomException;
 import com.example.demo.global.exception.errorcode.ErrorCode;
+import com.example.demo.security.SecurityResponseHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,12 +25,18 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class JsonWebTokenExceptionFilter extends OncePerRequestFilter {
 
+    private final SecurityResponseHandler securityResponseHandler;
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
             filterChain.doFilter(request, response);
-        } catch (TokenCustomException TokenCustomException) {
+        } catch (TokenCustomException tokenCustomException) {
+            // CustomException ErrorCode
+            ErrorCode errorCode = tokenCustomException.getErrorCode();
 
+            // 클라이언트로 응답 전송
+            securityResponseHandler.sendResponse(response, errorCode.getStatus(), ResponseDto.fail(errorCode.getMessage()));
         }
     }
 }

--- a/src/main/java/com/example/demo/security/jwt/JsonWebTokenLogoutFilter.java
+++ b/src/main/java/com/example/demo/security/jwt/JsonWebTokenLogoutFilter.java
@@ -32,8 +32,6 @@ public class JsonWebTokenLogoutFilter extends OncePerRequestFilter {
 
     private final RefreshTokenRedisService refreshTokenRedisService;
 
-    private final ObjectMapper objectMapper;
-
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         // 로그아웃 요청이 아닐 경우, 다음 필터체인 수행
@@ -67,7 +65,7 @@ public class JsonWebTokenLogoutFilter extends OncePerRequestFilter {
         expirationRefreshCookie(response);
 
         // 로그아웃 성공 응답
-        sendLogoutResponse(response);
+
     }
 
     // Redis 에서 회원의 RefreshToken 삭제
@@ -83,13 +81,5 @@ public class JsonWebTokenLogoutFilter extends OncePerRequestFilter {
         cookie.setMaxAge(0);
         cookie.setPath("/");
         response.addCookie(cookie);
-    }
-
-    // 로그아웃 응답 설정
-    private void sendLogoutResponse(HttpServletResponse response) throws IOException{
-        response.setStatus(HttpStatus.OK.value());
-        response.setCharacterEncoding("utf-8");
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.getWriter().write(objectMapper.writeValueAsString(ResponseDto.success("로그아웃이 완료되었습니다.")));
     }
 }

--- a/src/main/java/com/example/demo/security/jwt/JsonWebTokenLogoutFilter.java
+++ b/src/main/java/com/example/demo/security/jwt/JsonWebTokenLogoutFilter.java
@@ -1,6 +1,7 @@
 package com.example.demo.security.jwt;
 
 import com.example.demo.dto.common.ResponseDto;
+import com.example.demo.security.SecurityResponseHandler;
 import com.example.demo.security.custom.PrincipalDetails;
 import com.example.demo.service.token.RefreshTokenRedisService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,8 +30,8 @@ import java.io.IOException;
 public class JsonWebTokenLogoutFilter extends OncePerRequestFilter {
 
     private static final String DEFAULT_LOGOUT_REQUEST_URI = "/api/user/logout";
-
     private final RefreshTokenRedisService refreshTokenRedisService;
+    private final SecurityResponseHandler securityResponseHandler;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -64,8 +65,8 @@ public class JsonWebTokenLogoutFilter extends OncePerRequestFilter {
         // 쿠키에서 RefreshToken 삭제
         expirationRefreshCookie(response);
 
-        // 로그아웃 성공 응답
-
+        // 클라이언트로 응답 전송
+        securityResponseHandler.sendResponse(response, HttpStatus.OK, ResponseDto.success("로그아웃이 완료되었습니다."));
     }
 
     // Redis 에서 회원의 RefreshToken 삭제


### PR DESCRIPTION
### 작업내용
- 필터 별 각자 응답 처리를 하던 방법에서 SecurityResponseHandler를 통해 공통으로 응답을 처리하도록 수정
- 각 필터에 SecurityResponseHandler 객체의 의존성을 주입해 sendResponse() 메서드를 통해 공통으로 클라이언트로 응답을 전송하도록 수정
- 각 필터의 로직이 수정됨에 따라 SecurityConfig의 내용도 수정


### 연관이슈
#163 