### PR TITLE
[feature/fix-principal] PrincipalDetails 수정

### DIFF
--- a/src/main/java/com/example/demo/security/custom/PrincipalDetails.java
+++ b/src/main/java/com/example/demo/security/custom/PrincipalDetails.java
@@ -14,28 +14,23 @@ public class PrincipalDetails implements UserDetails {
     private Long id;
     private String email;
     private String password;
-    private String nickname;
-    private String profileImgSrc;
     private String role;
 
     public PrincipalDetails(User user) {
         this.id = user.getId();
         this.email = user.getEmail();
         this.password = user.getPassword();
-        this.nickname = user.getNickname();
-        this.profileImgSrc = user.getProfileImgSrc();
         this.role = user.getRole().name();
     }
 
-    public PrincipalDetails(String id, String email, String nickname, String role) {
+    public PrincipalDetails(String id, String email, String role) {
         this.id = Long.valueOf(id);
         this.email = email;
-        this.nickname = nickname;
         this.role = role;
     }
 
-    public static PrincipalDetails of(String id, String email, String nickname, String role) {
-        return new PrincipalDetails(id, email, nickname, role);
+    public static PrincipalDetails of(String id, String email, String role) {
+        return new PrincipalDetails(id, email, role);
     }
 
     // 회원 권한 정보 반환

--- a/src/main/java/com/example/demo/security/jwt/JsonWebTokenProvider.java
+++ b/src/main/java/com/example/demo/security/jwt/JsonWebTokenProvider.java
@@ -67,7 +67,6 @@ public class JsonWebTokenProvider {
 
         Claims claims = Jwts.claims().setSubject(principalDetails.getUsername());
         claims.put("email", principalDetails.getEmail());
-        claims.put("nickname", principalDetails.getNickname());
         claims.put("role", principalDetails.getAuthorities());
 
         String accessToken =
@@ -123,11 +122,10 @@ public class JsonWebTokenProvider {
         Claims claims = parseClaims(token);
 
         String email = String.valueOf(claims.get("email"));
-        String nickname = String.valueOf(claims.get("nickname"));
         String authority = String.valueOf(claims.get("role"));
 
         PrincipalDetails principalDetails =
-                PrincipalDetails.of(claims.getSubject(), email, nickname, authority);
+                PrincipalDetails.of(claims.getSubject(), email, authority);
 
         return new UsernamePasswordAuthenticationToken(
                 principalDetails, "", principalDetails.getAuthorities());


### PR DESCRIPTION
### 작업내용
- 회원 수정 시 변경될 수 있는 정보인 nickname, profileImgSrc 필드 PrincipalDetails에서 삭제
- PrincipalDetails 필드가 변경됨에 따라 JsonWebTokenProvider의 AccessToken을 생성하고, 토큰으로 회원의 인증 정보 객체를 반환하는 메소드 수정