### PR TITLE
[feature/163-fix-user-entity] 회원 엔티티 수정

### DIFF
--- a/src/main/java/com/example/demo/model/user/User.java
+++ b/src/main/java/com/example/demo/model/user/User.java
@@ -37,9 +37,7 @@ public class User extends BaseTimeEntity {
 
     @OneToMany(
             mappedBy = "user",
-            fetch = FetchType.LAZY,
-            cascade = CascadeType.PERSIST,
-            orphanRemoval = true)
+            fetch = FetchType.LAZY)
     private List<UserTechnologyStack> techStacks = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/example/demo/model/user/User.java
+++ b/src/main/java/com/example/demo/model/user/User.java
@@ -43,9 +43,9 @@ public class User extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "trust_score_id")
-    TrustScore trustScore;
+    private TrustScore trustScore;
 
     @Builder
     private User(


### PR DESCRIPTION
### 작업내용
- 회원 엔티티의 List<UserTechnologyStack> 타입의 techStacks 필드의 OneToMany 연관관계 옵션 중 연쇄관련 cascade, orphanRemoval 옵션 삭제, UserTechnologyStack 엔티티는 다대다 관계의 중간 엔티티이기 때문에 연쇄 옵션을 삭제
- 회원 엔티티의 trustScore 필드에 fetch 타입을 명시하고 접근 제어자 private으로 수정