### PR TITLE
[feat/175-get-types] feat : 신뢰점수타입 조건 별 조회 기능 추가

### DIFF
--- a/src/main/java/com/example/demo/controller/trust_score/TrustScoreTypeController.java
+++ b/src/main/java/com/example/demo/controller/trust_score/TrustScoreTypeController.java
@@ -1,13 +1,14 @@
 package com.example.demo.controller.trust_score;
 
 import com.example.demo.dto.common.ResponseDto;
+import com.example.demo.dto.trust_score_type.TrustScoreTypeSearchCriteria;
 import com.example.demo.dto.trust_score_type.response.TrustScoreTypeReadResponseDto;
-import com.example.demo.service.trust_score.TrustScoreService;
 import com.example.demo.service.trust_score.TrustScoreTypeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -20,5 +21,26 @@ public class TrustScoreTypeController {
     public ResponseEntity<ResponseDto<?>> getAll() {
         List<TrustScoreTypeReadResponseDto> dto = trustScoreTypeService.getAllAndReturnDto();
         return new ResponseEntity<>(ResponseDto.success("success",dto), HttpStatus.OK);
+    }
+
+    @GetMapping("/api/trust-score-type/search")
+    public ResponseEntity<ResponseDto<?>> getSearchResults(
+            @RequestParam(name = "isDeleted", required = false) Boolean isDeleted,
+            @RequestParam(name = "isParentType", required = false) Boolean isParentType,
+            @RequestParam(name = "trustGrade", required = false) List<String> trustGrade,
+            @RequestParam(name = "parentTypeId", required = false) List<Long> parentTypeId,
+            @RequestParam(name = "gubunCode", required = false) String gubunCode
+    ) {
+        TrustScoreTypeSearchCriteria criteria =
+                TrustScoreTypeSearchCriteria.builder()
+                        .isParentType(isDeleted)
+                        .isParentType(isParentType)
+                        .trustGrade(trustGrade)
+                        .parentTypeId(parentTypeId)
+                        .gubunCode(gubunCode)
+                        .build();
+
+        List<TrustScoreTypeReadResponseDto> searchResults = trustScoreTypeService.getSearchResults(criteria);
+        return new ResponseEntity<>(ResponseDto.success("success", searchResults), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/demo/dto/trust_score_type/TrustScoreTypeSearchCriteria.java
+++ b/src/main/java/com/example/demo/dto/trust_score_type/TrustScoreTypeSearchCriteria.java
@@ -1,0 +1,20 @@
+package com.example.demo.dto.trust_score_type;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TrustScoreTypeSearchCriteria {
+    private Boolean isDeleted;
+    private Boolean isParentType;
+    private List<String> trustGrade;
+    private List<Long> parentTypeId;
+    private String gubunCode;
+}

--- a/src/main/java/com/example/demo/dto/trust_score_type/response/TrustScoreTypeReadResponseDto.java
+++ b/src/main/java/com/example/demo/dto/trust_score_type/response/TrustScoreTypeReadResponseDto.java
@@ -1,33 +1,24 @@
 package com.example.demo.dto.trust_score_type.response;
 
 import com.example.demo.model.trust_score.TrustScoreType;
-import lombok.AllArgsConstructor;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
-
 import java.time.LocalDateTime;
-import java.util.Date;
+
 
 @Getter
-@AllArgsConstructor
 @Builder
 public class TrustScoreTypeReadResponseDto {
 
     private Long trustScoreTypeId;
     private String upTrustScoreTypeName;
     private String trustScoreTypeName;
-
     private String trustGradeName;
-
     private Integer score;
-
     private String gubunCode;
-
     private String deleteStatus;
-
     private LocalDateTime createDate;
-
     private LocalDateTime updateDate;
 
     public static TrustScoreTypeReadResponseDto of(TrustScoreType trustScoreType) {
@@ -49,5 +40,20 @@ public class TrustScoreTypeReadResponseDto {
             return null;
         }
         return trustScoreType.getTrustScoreTypeName();
+    }
+    @QueryProjection
+    public TrustScoreTypeReadResponseDto(Long trustScoreTypeId, String upTrustScoreTypeName,
+                                         String trustScoreTypeName, String trustGradeName,
+                                         Integer score, String gubunCode, String deleteStatus,
+                                         LocalDateTime createDate, LocalDateTime updateDate) {
+        this.trustScoreTypeId = trustScoreTypeId;
+        this.upTrustScoreTypeName = upTrustScoreTypeName;
+        this.trustScoreTypeName = trustScoreTypeName;
+        this.trustGradeName = trustGradeName;
+        this.score = score;
+        this.gubunCode = gubunCode;
+        this.deleteStatus = deleteStatus;
+        this.createDate = createDate;
+        this.updateDate = updateDate;
     }
 }

--- a/src/main/java/com/example/demo/repository/trust_score/TrustScoreTypeRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/trust_score/TrustScoreTypeRepositoryCustom.java
@@ -1,5 +1,10 @@
 package com.example.demo.repository.trust_score;
 
+import com.example.demo.dto.trust_score_type.TrustScoreTypeSearchCriteria;
+import com.example.demo.dto.trust_score_type.response.TrustScoreTypeReadResponseDto;
+import com.example.demo.model.trust_score.TrustScore;
+import com.example.demo.model.trust_score.TrustScoreType;
+
 import java.util.List;
 
 public interface TrustScoreTypeRepositoryCustom {
@@ -22,4 +27,6 @@ public interface TrustScoreTypeRepositoryCustom {
      * @return List<Long>
      */
     List<Long> findAllUpScoreTypeId();
+
+    List<TrustScoreTypeReadResponseDto> findSearchResults(TrustScoreTypeSearchCriteria criteria);
 }

--- a/src/main/java/com/example/demo/service/trust_score/TrustScoreTypeService.java
+++ b/src/main/java/com/example/demo/service/trust_score/TrustScoreTypeService.java
@@ -1,9 +1,13 @@
 package com.example.demo.service.trust_score;
 
+import com.example.demo.dto.trust_score_type.TrustScoreTypeSearchCriteria;
 import com.example.demo.dto.trust_score_type.response.TrustScoreTypeReadResponseDto;
+import com.example.demo.model.trust_score.TrustScoreType;
 
 import java.util.List;
 
 public interface TrustScoreTypeService {
     List<TrustScoreTypeReadResponseDto> getAllAndReturnDto();
+    List<TrustScoreTypeReadResponseDto> getSearchResults(
+            TrustScoreTypeSearchCriteria criteria);
 }

--- a/src/main/java/com/example/demo/service/trust_score/TrustScoreTypeServiceImpl.java
+++ b/src/main/java/com/example/demo/service/trust_score/TrustScoreTypeServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.demo.service.trust_score;
 
+import com.example.demo.dto.trust_score_type.TrustScoreTypeSearchCriteria;
 import com.example.demo.dto.trust_score_type.response.TrustScoreTypeReadResponseDto;
 import com.example.demo.model.trust_score.TrustScoreType;
 import com.example.demo.repository.trust_score.TrustScoreHistoryRepository;
@@ -18,5 +19,11 @@ public class TrustScoreTypeServiceImpl implements TrustScoreTypeService {
         List<TrustScoreType> findAllTrustScoreType = trustScoreTypeRepository.findAll();
         return findAllTrustScoreType.stream().map(TrustScoreTypeReadResponseDto::of)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<TrustScoreTypeReadResponseDto> getSearchResults(
+            TrustScoreTypeSearchCriteria criteria) {
+        return trustScoreTypeRepository.findSearchResults(criteria);
     }
 }

--- a/src/test/java/com/example/demo/trust_score/repository/TrustScoreTypeRepositoryTest.java
+++ b/src/test/java/com/example/demo/trust_score/repository/TrustScoreTypeRepositoryTest.java
@@ -1,6 +1,8 @@
 package com.example.demo.trust_score.repository;
 
 import com.example.demo.constant.TrustScoreTypeIdentifier;
+import com.example.demo.dto.trust_score_type.TrustScoreTypeSearchCriteria;
+import com.example.demo.dto.trust_score_type.response.TrustScoreTypeReadResponseDto;
 import com.example.demo.global.exception.customexception.TrustGradeCustomException;
 import com.example.demo.global.exception.customexception.TrustScoreTypeCustomException;
 import com.example.demo.model.project.Project;
@@ -19,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import static com.example.demo.constant.TrustScoreTypeIdentifier.*;
 
@@ -126,7 +129,7 @@ public class TrustScoreTypeRepositoryTest {
     // TODO : 더 나은 테스트 방식 고민
     @Test
     @DisplayName("신뢰점수타입 참조 작동 여부 확인")
-    public void ParentTrustScoreType_Contains_Children_Test() {
+    public void UpTrustScoreType_Contains_Children_MappedBy_Test() {
         // given
         // 업무완수 신뢰점수타입 조회
         TrustScoreType parent = trustScoreTypeRepository.findById(WORK_COMPLETE)
@@ -140,5 +143,136 @@ public class TrustScoreTypeRepositoryTest {
         // then
         Assertions.assertThat(children.size()).isEqualTo(4);
 
+    }
+
+    @Test
+    @DisplayName("검색 조건 없음 - 전체 조회")
+    public void getSearchResults_NoCriteria_Pass() {
+        // given
+        TrustScoreTypeSearchCriteria criteria = new TrustScoreTypeSearchCriteria();
+
+        // when
+        List<TrustScoreTypeReadResponseDto> searchResults =
+                trustScoreTypeRepository.findSearchResults(criteria);
+
+        for (TrustScoreTypeReadResponseDto searchResult : searchResults) {
+            System.out.println(searchResult.getTrustScoreTypeName());
+
+        }
+
+        // then
+        Assertions.assertThat(searchResults.size()).isEqualTo(26);
+
+    }
+
+    @Test
+    @DisplayName("검색 결과 없음")
+    public void getSearchResults_NewMember_firstTrustGrade_NoResult_Pass() {
+        // given
+        TrustScoreTypeSearchCriteria criteria = new TrustScoreTypeSearchCriteria();
+        List<Long> newMember = Collections.singletonList(3L);
+        List<String> firstTrustGrade = Collections.singletonList("1등급");
+        criteria.setParentTypeId(newMember);
+        criteria.setTrustGrade(firstTrustGrade);
+
+        // when
+        List<TrustScoreTypeReadResponseDto> searchResults =
+                trustScoreTypeRepository.findSearchResults(criteria);
+
+        // then
+        Assertions.assertThat(searchResults).isEmpty();
+
+    }
+
+    @Test
+    @DisplayName("상위신뢰점수타입 조회")
+    public void getSearchResults_isParentType() {
+        // given
+        TrustScoreTypeSearchCriteria criteria = new TrustScoreTypeSearchCriteria();
+        criteria.setIsParentType(true);
+
+        // when
+        List<TrustScoreTypeReadResponseDto> searchResults =
+                trustScoreTypeRepository.findSearchResults(criteria);
+
+        // then
+        Assertions.assertThat(searchResults.size()).isEqualTo(6);
+
+    }
+
+    @Test
+    @DisplayName("구분코드가 P 신뢰점수타입 조회")
+    public void getSearchResults_gubunCodePlus() {
+        // given
+        TrustScoreTypeSearchCriteria criteria = new TrustScoreTypeSearchCriteria();
+        criteria.setGubunCode("P");
+
+        // when
+        List<TrustScoreTypeReadResponseDto> searchResults =
+                trustScoreTypeRepository.findSearchResults(criteria);
+
+        // then
+        Assertions.assertThat(searchResults.size()).isEqualTo(6);
+
+    }
+    @Test
+    @DisplayName("1등급, 2등급 신뢰점수타입 조회")
+    public void getSearchResults_FirstAndSecondGrade_Test_Pass() {
+        // given
+        TrustScoreTypeSearchCriteria criteria = new TrustScoreTypeSearchCriteria();
+        List<String> grades = new ArrayList<>();
+        grades.add("1등급");
+        grades.add("2등급");
+        criteria.setTrustGrade(grades);
+
+        // when
+        List<TrustScoreTypeReadResponseDto> searchResults = trustScoreTypeRepository.findSearchResults(criteria);
+
+        // then
+        Assertions.assertThat(searchResults.size()).isEqualTo(10);
+
+    }
+    // TODO : 실패 expected 2, returned 0
+    @Test
+    @DisplayName("1등급, 2등급 및 신규회원, 강제탈퇴 신뢰점수타입 조회")
+    public void getSearchResults_FirstAndSecondGrade_NewMemberAndForceWithdrawal_Test_Pass() {
+        // given
+        TrustScoreTypeSearchCriteria criteria = new TrustScoreTypeSearchCriteria();
+
+        List<String> grades = new ArrayList<>();
+        grades.add("1등급");
+        grades.add("2등급");
+        criteria.setTrustGrade(grades);
+
+        List<Long> ids = new ArrayList<>();
+        ids.add(NEW_MEMBER);
+        ids.add(FORCE_WITHDRAWAL);
+        criteria.setParentTypeId(ids);
+
+        // when
+        List<TrustScoreTypeReadResponseDto> searchResults = trustScoreTypeRepository.findSearchResults(criteria);
+
+        // then
+        Assertions.assertThat(searchResults.size()).isEqualTo(2);
+
+
+    }
+
+    @Test
+    @DisplayName("1등급, 2등급 및 신규회원, 강제탈퇴 신뢰점수타입 조회")
+    public void getSearchResults_NewMemberAndForceWithdrawal_Test_Pass() {
+        // given
+        TrustScoreTypeSearchCriteria criteria = new TrustScoreTypeSearchCriteria();
+
+        List<Long> ids = new ArrayList<>();
+        ids.add(NEW_MEMBER);
+        ids.add(FORCE_WITHDRAWAL);
+        criteria.setParentTypeId(ids);
+
+        // when
+        List<TrustScoreTypeReadResponseDto> searchResults = trustScoreTypeRepository.findSearchResults(criteria);
+
+        // then
+        Assertions.assertThat(searchResults.size()).isEqualTo(6);
     }
 }


### PR DESCRIPTION
검색 조건에 따라 다른 신뢰점수타입을 반환하는 기능을 추가했습니다.

해당 로직을 수행하는 Controller, Service, Repository class 생성했습니다.

테스트를 통해 기능이 정상 작동되는 것을 확인했습니다.