### PR TITLE
[feature/163-user-update] 회원 수정 로직 구현

### DIFF
--- a/src/main/java/com/example/demo/controller/user/UserController.java
+++ b/src/main/java/com/example/demo/controller/user/UserController.java
@@ -2,12 +2,16 @@ package com.example.demo.controller.user;
 
 import com.example.demo.dto.common.ResponseDto;
 import com.example.demo.dto.user.request.UserCreateRequestDto;
+import com.example.demo.dto.user.request.UserUpdateRequestDto;
+import com.example.demo.dto.user.response.UserUpdateResponseDto;
+import com.example.demo.security.custom.PrincipalDetails;
 import com.example.demo.service.user.UserFacade;
 import com.example.demo.service.user.UserService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -34,5 +38,11 @@ public class UserController {
     public ResponseEntity<ResponseDto<?>> signup(
             @Valid @RequestBody UserCreateRequestDto createRequest) {
         return ResponseEntity.status(HttpStatus.CREATED).body(userFacade.createUser(createRequest));
+    }
+
+    // 회원수정
+    @PutMapping("/api/user")
+    public ResponseEntity<ResponseDto<?>> update(@AuthenticationPrincipal PrincipalDetails user, @Valid @RequestBody UserUpdateRequestDto updateRequest) {
+        return ResponseEntity.status(HttpStatus.OK).body(userFacade.updateUser(user, updateRequest));
     }
 }

--- a/src/main/java/com/example/demo/dto/user/request/UserUpdateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/user/request/UserUpdateRequestDto.java
@@ -4,14 +4,23 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
 @Getter
 @AllArgsConstructor
 public class UserUpdateRequestDto {
 
+    @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9]{6,10}$", message = "닉네임은 영문과 숫자를 조합하여 6자~10자 사이로 설정해주세요.")
     private String nickname;
 
+    @NotNull(message = "직무는 필수 선택 값입니다.")
     private Long positionId;
 
+    @NotEmpty(message = "관심스택은 필수 선택 값입니다.")
     private List<Long> techStackIds;
 
     private String intro;

--- a/src/main/java/com/example/demo/dto/user/response/UserUpdateResponseDto.java
+++ b/src/main/java/com/example/demo/dto/user/response/UserUpdateResponseDto.java
@@ -1,0 +1,33 @@
+package com.example.demo.dto.user.response;
+
+import com.example.demo.dto.position.response.PositionInfoResponseDto;
+import com.example.demo.dto.technology_stack.response.TechnologyStackInfoResponseDto;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class UserUpdateResponseDto {
+
+    private String email;
+
+    private String nickname;
+
+    private PositionInfoResponseDto position;
+
+    private List<TechnologyStackInfoResponseDto> techStacks;
+
+    private String intro;
+
+    public static UserUpdateResponseDto of(String email, String nickname, PositionInfoResponseDto positionInfoResponseDto, List<TechnologyStackInfoResponseDto> techStacks, String intro) {
+        return UserUpdateResponseDto.builder()
+                .email(email)
+                .nickname(nickname)
+                .position(positionInfoResponseDto)
+                .techStacks(techStacks)
+                .intro(intro)
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/model/user/User.java
+++ b/src/main/java/com/example/demo/model/user/User.java
@@ -70,6 +70,23 @@ public class User extends BaseTimeEntity {
         this.techStacks = techStacks;
     }
 
+    // 기술스택 삭제
+    public void removeTechStack(UserTechnologyStack userTechnologyStack) {
+        this.techStacks.remove(userTechnologyStack);
+    }
+
+    // 기술스택 추가
+    public void addTechStack(UserTechnologyStack userTechnologyStack) {
+        this.techStacks.add(userTechnologyStack);
+    }
+
     // 신뢰점수 등록
     public void setTrustScore(TrustScore trustScore) {this.trustScore = trustScore;}
+
+    // 회원 수정
+    public void update(String nickname, Position position, String intro) {
+        this.nickname = nickname;
+        this.position = position;
+        this.intro = intro;
+    }
 }

--- a/src/main/java/com/example/demo/repository/user/UserRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/user/UserRepositoryCustom.java
@@ -1,4 +1,9 @@
 package com.example.demo.repository.user;
 
+import com.example.demo.model.user.User;
+
 public interface UserRepositoryCustom {
+
+    // 회원 업데이트를 위한 사용자 세부 정보 가져오기(포지션, 회원 기술스택, 기술스택)
+    User fetchUserDetailsForUpdate(Long userId);
 }

--- a/src/main/java/com/example/demo/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/user/UserRepositoryImpl.java
@@ -1,5 +1,9 @@
 package com.example.demo.repository.user;
 
+import com.example.demo.model.technology_stack.QTechnologyStack;
+import com.example.demo.model.user.QUser;
+import com.example.demo.model.user.QUserTechnologyStack;
+import com.example.demo.model.user.User;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -9,4 +13,18 @@ import org.springframework.stereotype.Repository;
 public class UserRepositoryImpl implements UserRepositoryCustom {
 
     private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public User fetchUserDetailsForUpdate(Long userId) {
+        QUser qUser = QUser.user;
+        QUserTechnologyStack qUserTechnologyStack = QUserTechnologyStack.userTechnologyStack;
+        QTechnologyStack qTechnologyStack = QTechnologyStack.technologyStack;
+
+        return jpaQueryFactory
+                .selectFrom(qUser)
+                .leftJoin(qUser.techStacks, qUserTechnologyStack).fetchJoin()
+                .leftJoin(qUserTechnologyStack.technologyStack, qTechnologyStack).fetchJoin()
+                .where(qUser.id.eq(userId))
+                .fetchOne();
+    }
 }

--- a/src/main/java/com/example/demo/service/user/UserFacade.java
+++ b/src/main/java/com/example/demo/service/user/UserFacade.java
@@ -3,9 +3,13 @@ package com.example.demo.service.user;
 import com.example.demo.constant.Role;
 import com.example.demo.constant.TrustScoreTypeIdentifier;
 import com.example.demo.dto.common.ResponseDto;
+import com.example.demo.dto.position.response.PositionInfoResponseDto;
+import com.example.demo.dto.technology_stack.response.TechnologyStackInfoResponseDto;
 import com.example.demo.dto.trust_score.AddPointDto;
 import com.example.demo.dto.trust_score.request.TrustScoreUpdateRequestDto;
 import com.example.demo.dto.user.request.UserCreateRequestDto;
+import com.example.demo.dto.user.request.UserUpdateRequestDto;
+import com.example.demo.dto.user.response.UserUpdateResponseDto;
 import com.example.demo.global.exception.customexception.TrustScoreCustomException;
 import com.example.demo.model.position.Position;
 import com.example.demo.model.technology_stack.TechnologyStack;
@@ -13,6 +17,7 @@ import com.example.demo.model.trust_score.TrustScore;
 import com.example.demo.model.user.User;
 import com.example.demo.model.user.UserTechnologyStack;
 import com.example.demo.repository.trust_score.TrustScoreRepository;
+import com.example.demo.security.custom.PrincipalDetails;
 import com.example.demo.service.position.PositionService;
 import com.example.demo.service.technology_stack.TechnologyStackService;
 import com.example.demo.service.trust_score.TrustScoreService;
@@ -36,7 +41,11 @@ public class UserFacade {
     private final TrustScoreService trustScoreService;
     private final UserTechnologyStackService userTechnologyStackService;
 
-    // 회원가입
+    /**
+     * 회원가입 로직
+     * @param createRequest
+     * @return user.id
+     */
     @Transactional
     public ResponseDto<?> createUser(UserCreateRequestDto createRequest) {
         // 패스워드 암호화
@@ -89,6 +98,57 @@ public class UserFacade {
         return trustScoreService.findTrustScoreByUserId(user.getId());
     }
 
+    /**
+     * 회원수정 로직
+     * @param user
+     * @param updateRequest
+     * @return updateResponse
+     */
+    @Transactional
+    public ResponseDto<?> updateUser(PrincipalDetails user, UserUpdateRequestDto updateRequest) {
+        User currentUser = userService.getUserForUpdate(user.getId());
+
+        // 기존 포지션과 수정 요청한 포지션 비교
+        Position position = currentUser.getPosition();
+        // 다르면 포지션 수정
+        if(!isPositionDiff(position.getId(), updateRequest.getPositionId())) {
+            position = positionService.findById(updateRequest.getPositionId());
+        }
+
+        // 삭제할 기술스택 확인
+        List<UserTechnologyStack> deleteList = hasTechStackToRemove(currentUser.getTechStacks(), updateRequest.getTechStackIds());
+        if(!deleteList.isEmpty()) {
+            // 저장된 UserTechnologyStack 삭제
+            userTechnologyStackService.deleteUserTechnologyStackList(deleteList);
+            // 회원 기술스택 목록에서 삭제
+            deleteList.forEach(currentUser::removeTechStack);
+        }
+
+        // 추가할 기술스택 확인
+        List<Long> addTechStackIds = hasTechStackToAdd(currentUser.getTechStacks(), updateRequest.getTechStackIds());
+        if(!addTechStackIds.isEmpty()) {
+            // 새로운 UserTechnologyStack 저장
+            List<UserTechnologyStack> addList = saveTechStacksAndReturnResponse(currentUser, addTechStackIds);
+            // 회원 기술스택 목록에 추가
+            addList.forEach(currentUser::addTechStack);
+        }
+
+        // 회원 수정
+        currentUser.update(updateRequest.getNickname(), position, updateRequest.getIntro());
+
+        // 수정된 회원의 기술스택 목록 List<TechnologyStackInfoResponseDto> 타입으로 변환
+        List<TechnologyStackInfoResponseDto> infoTechStacks = currentUser.getTechStacks().stream()
+                .map(userTechnologyStack -> TechnologyStackInfoResponseDto.of(userTechnologyStack.getTechnologyStack().getId(), userTechnologyStack.getTechnologyStack().getName()))
+                .collect(Collectors.toList());
+
+        // 회원 수정 응답 객체 생성
+        UserUpdateResponseDto updateResponse = UserUpdateResponseDto.of(currentUser.getEmail(), currentUser.getNickname(),
+                PositionInfoResponseDto.of(position.getId(), position.getName()),
+                infoTechStacks, currentUser.getIntro());
+
+        return ResponseDto.success("회원수정이 완료되었습니다.", updateResponse);
+    }
+
     // 회원 기술스택 목록 저장 및 반환
     private List<UserTechnologyStack> saveTechStacksAndReturnResponse(User user, List<Long> techStackIds) {
         // 요청한 기술스택 목록 조회
@@ -112,5 +172,35 @@ public class UserFacade {
                 .user(user)
                 .technologyStack(technologyStack)
                 .build();
+    }
+
+    // 기존 포지션과 요청한 포지션 비교
+    private boolean isPositionDiff(Long currentPositionId, Long requestUpdatePositionId) {
+        return currentPositionId.equals(requestUpdatePositionId);
+    }
+
+    // 기존 기술스택 목록 중 삭제해야 될 기술스택이 있는지 조회
+    private List<UserTechnologyStack> hasTechStackToRemove(List<UserTechnologyStack> currentTechStackList, List<Long> requestUpdateTechStackList) {
+        List<UserTechnologyStack> deleteList = new ArrayList<>();
+        for(UserTechnologyStack userTechnologyStack : currentTechStackList) {
+            TechnologyStack technologyStack = userTechnologyStack.getTechnologyStack();
+
+            if(!requestUpdateTechStackList.contains(technologyStack.getId())) {
+                deleteList.add(userTechnologyStack);
+            }
+        }
+
+        return deleteList;
+    }
+
+    // 요청한 기술스택 목록 중 추가해야 될 기술스택이 있는지 조회
+    private List<Long> hasTechStackToAdd(List<UserTechnologyStack> currentTechStackList, List<Long> requestUpdateTechStackList) {
+        List<Long> currentList = currentTechStackList.stream()
+                .map(userTechnologyStack -> userTechnologyStack.getTechnologyStack().getId())
+                .collect(Collectors.toList());
+
+        requestUpdateTechStackList.removeAll(currentList);
+
+        return requestUpdateTechStackList;
     }
 }

--- a/src/main/java/com/example/demo/service/user/UserService.java
+++ b/src/main/java/com/example/demo/service/user/UserService.java
@@ -17,4 +17,7 @@ public interface UserService {
     User findById(Long userId);
 
     User save(User user);
+
+    // 회원 수정 시 회원 정보 조회
+    User getUserForUpdate(Long userId);
 }

--- a/src/main/java/com/example/demo/service/user/UserServiceImpl.java
+++ b/src/main/java/com/example/demo/service/user/UserServiceImpl.java
@@ -40,4 +40,9 @@ public class UserServiceImpl implements UserService {
     public User save(User user) {
         return userRepository.save(user);
     }
+
+    @Override
+    public User getUserForUpdate(Long userId) {
+        return userRepository.fetchUserDetailsForUpdate(userId);
+    }
 }


### PR DESCRIPTION
### 작업내용
- 회원 수정 요청 시 필요한 회원의 정보만 조회하는 로직을 queryDsl로 구현
- 클라이언트로부터 nickname, positionId, techStackIds, intro 4개의 수정 요청 데이터를 받고 positionId와 techStacksIds는 기존 회원의 정보와 비교하여 수정하도록 구현
- 회원 엔티티 영역에서 회원 기술스택을 삭제, 추가하는 로직과 회원 정보를 수정하는 로직 구현
- 수정된 데이터를 클라이언트로 응답하도록 구현


### 연관이슈
#163 