### PR TITLE
[feature/user-tech-stack-refactor] 회원 기술스택 조작 관련 로직 분리

### DIFF
--- a/src/main/java/com/example/demo/service/user/UserFacade.java
+++ b/src/main/java/com/example/demo/service/user/UserFacade.java
@@ -149,31 +149,6 @@ public class UserFacade {
         return ResponseDto.success("회원수정이 완료되었습니다.", updateResponse);
     }
 
-    // 회원 기술스택 목록 저장 및 반환
-    private List<UserTechnologyStack> saveTechStacksAndReturnResponse(User user, List<Long> techStackIds) {
-        // 요청한 기술스택 목록 조회
-        List<TechnologyStack> techStackList = technologyStackService.findTechnologyStackListByIds(techStackIds);
-        List<UserTechnologyStack> userTechStackList = createUserTechnologyStackList(user, techStackList);
-
-        // 회원 기술스택 목록 저장
-        return userTechnologyStackService.saveAll(userTechStackList);
-    }
-
-    // 회원 기술스택 목록 생성
-    private List<UserTechnologyStack> createUserTechnologyStackList(User user, List<TechnologyStack> techStackList) {
-        return techStackList.stream()
-                .map(tech -> createUserTechnologyStack(user, tech))
-                .collect(Collectors.toList());
-    }
-
-    // 회원 기술스택 엔티티 생성
-    private UserTechnologyStack createUserTechnologyStack(User user, TechnologyStack technologyStack) {
-        return UserTechnologyStack.builder()
-                .user(user)
-                .technologyStack(technologyStack)
-                .build();
-    }
-
     // 기존 포지션과 요청한 포지션 비교
     private boolean isPositionDiff(Long currentPositionId, Long requestUpdatePositionId) {
         return currentPositionId.equals(requestUpdatePositionId);

--- a/src/main/java/com/example/demo/service/user/UserTechnologyStackService.java
+++ b/src/main/java/com/example/demo/service/user/UserTechnologyStackService.java
@@ -1,14 +1,16 @@
 package com.example.demo.service.user;
 
+import com.example.demo.model.technology_stack.TechnologyStack;
+import com.example.demo.model.user.User;
 import com.example.demo.model.user.UserTechnologyStack;
 
 import java.util.List;
 
 public interface UserTechnologyStackService {
 
-    // 회원 기술스택 리스트 저장
-    List<UserTechnologyStack> saveAll(List<UserTechnologyStack> technologyStackList);
+    // 회원 기술스택 목록 저장 및 반환
+    List<UserTechnologyStack> saveUserTechStacksAndReturnResponse(User user, List<TechnologyStack> technologyStackList);
 
     // 회원 기술스택 목록 삭제
-    void deleteUserTechnologyStackList(List<UserTechnologyStack> technologyStackList);
+    void deleteUserTechStacks(List<UserTechnologyStack> technologyStackList);
 }

--- a/src/main/java/com/example/demo/service/user/UserTechnologyStackServiceImpl.java
+++ b/src/main/java/com/example/demo/service/user/UserTechnologyStackServiceImpl.java
@@ -17,9 +17,8 @@ public class UserTechnologyStackServiceImpl implements UserTechnologyStackServic
 
     private final UserTechnologyStackRepository userTechnologyStackRepository;
 
-
     @Override
-    public List<UserTechnologyStack> saveAll(List<UserTechnologyStack> technologyStackList) {
+    public List<UserTechnologyStack> saveUserTechStacksAndReturnResponse(User user, List<TechnologyStack> technologyStackList) {
         return userTechnologyStackRepository.saveAll(technologyStackList);
     }
 
@@ -39,7 +38,7 @@ public class UserTechnologyStackServiceImpl implements UserTechnologyStackServic
     }
 
     @Override
-    public void deleteUserTechnologyStackList(List<UserTechnologyStack> technologyStackList) {
+    public void deleteUserTechStacks(List<UserTechnologyStack> technologyStackList) {
         userTechnologyStackRepository.deleteAll(technologyStackList);
     }
 }

--- a/src/main/java/com/example/demo/service/user/UserTechnologyStackServiceImpl.java
+++ b/src/main/java/com/example/demo/service/user/UserTechnologyStackServiceImpl.java
@@ -19,7 +19,9 @@ public class UserTechnologyStackServiceImpl implements UserTechnologyStackServic
 
     @Override
     public List<UserTechnologyStack> saveUserTechStacksAndReturnResponse(User user, List<TechnologyStack> technologyStackList) {
-        return userTechnologyStackRepository.saveAll(technologyStackList);
+        List<UserTechnologyStack> userTechnologyStackList = createUserTechnologyStackList(user, technologyStackList);
+
+        return userTechnologyStackRepository.saveAll(userTechnologyStackList);
     }
 
     // 회원 기술스택 목록 생성

--- a/src/main/java/com/example/demo/service/user/UserTechnologyStackServiceImpl.java
+++ b/src/main/java/com/example/demo/service/user/UserTechnologyStackServiceImpl.java
@@ -1,11 +1,15 @@
 package com.example.demo.service.user;
 
+import com.example.demo.model.technology_stack.TechnologyStack;
+import com.example.demo.model.user.User;
 import com.example.demo.model.user.UserTechnologyStack;
 import com.example.demo.repository.user.UserTechnologyStackRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +21,21 @@ public class UserTechnologyStackServiceImpl implements UserTechnologyStackServic
     @Override
     public List<UserTechnologyStack> saveAll(List<UserTechnologyStack> technologyStackList) {
         return userTechnologyStackRepository.saveAll(technologyStackList);
+    }
+
+    // 회원 기술스택 목록 생성
+    private List<UserTechnologyStack> createUserTechnologyStackList(User user, List<TechnologyStack> techStackList) {
+        return techStackList.stream()
+                .map(tech -> createUserTechnologyStack(user, tech))
+                .collect(Collectors.toList());
+    }
+
+    // 회원 기술스택 엔티티 생성
+    private UserTechnologyStack createUserTechnologyStack(User user, TechnologyStack technologyStack) {
+        return UserTechnologyStack.builder()
+                .user(user)
+                .technologyStack(technologyStack)
+                .build();
     }
 
     @Override


### PR DESCRIPTION
### 작업내용
- UserFacade에서 회원 기술스택 조작관련 로직을 분리해서 UserTechnologyStackService에서 구현하고 UserFacade 클래스도 함께 수정
- UserTechnologyStackService의 저장, 삭제 로직을 비지니스 로직에 맞춰 수정(메소드명, 파라미터 타입, 로직)
- 회원 기술스택 엔티티와 회원 기술스택 목록을 생성하고 저장하는 로직을 분리