### PR TITLE
[feature/get-user-project-history] 회원 프로젝트 이력 조회 로직 구현

### DIFF
--- a/src/main/java/com/example/demo/dto/user/response/UserProjectHistoryInfoResponseDto.java
+++ b/src/main/java/com/example/demo/dto/user/response/UserProjectHistoryInfoResponseDto.java
@@ -1,0 +1,18 @@
+package com.example.demo.dto.user.response;
+
+import com.example.demo.constant.UserProjectHistoryStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class UserProjectHistoryInfoResponseDto {
+
+    private Long userProjectHistoryId;
+
+    private UserProjectHistoryStatus status;
+
+    private String projectName;
+
+    private String updateDate;
+}

--- a/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepository.java
+++ b/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepository.java
@@ -3,4 +3,4 @@ package com.example.demo.repository.user;
 import com.example.demo.model.user.UserProjectHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserProjectHistoryRepository extends JpaRepository<UserProjectHistory, Long> {}
+public interface UserProjectHistoryRepository extends JpaRepository<UserProjectHistory, Long>, UserProjectHistoryRepositoryCustom {}

--- a/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepositoryCustom.java
@@ -1,0 +1,16 @@
+package com.example.demo.repository.user;
+
+import com.example.demo.dto.user.response.UserProjectHistoryInfoResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface UserProjectHistoryRepositoryCustom {
+
+    // 회원 프로젝트 이력 전체 개수 조회
+    Long countUserProjectHistoryByUserId(Long userId);
+
+    // 회원 프로젝트 이력 목록 조회 (수정날짜 기준 최신순 정렬, 페이징 offset 방법 활용)
+    List<UserProjectHistoryInfoResponseDto> findAllByUserIdOrderByUpdateDateDesc(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepositoryImpl.java
@@ -1,0 +1,65 @@
+package com.example.demo.repository.user;
+
+import static com.example.demo.model.user.QUser.user;
+import static com.example.demo.model.user.QUserProjectHistory.userProjectHistory;
+import static com.example.demo.model.project.QProject.project;
+
+import com.example.demo.dto.user.response.UserProjectHistoryInfoResponseDto;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class UserProjectHistoryRepositoryImpl implements UserProjectHistoryRepositoryCustom{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Long countUserProjectHistoryByUserId(Long userId) {
+        // 회원의 전체 프로젝트 이력 개수 조회
+        return  jpaQueryFactory
+                .select(userProjectHistory.count())
+                .from(userProjectHistory)
+                .leftJoin(userProjectHistory.user, user)
+                .where(userProjectHistory.user.id.eq(userId))
+                .fetchOne();
+    }
+
+    @Override
+    public List<UserProjectHistoryInfoResponseDto> findAllByUserIdOrderByUpdateDateDesc(Long userId, Pageable pageable) {
+        // 요청한 페이지의 회원 프로젝트 이력 목록 조회
+        List<UserProjectHistoryInfoResponseDto> content = jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                UserProjectHistoryInfoResponseDto.class,
+                                userProjectHistory.id,
+                                userProjectHistory.status,
+                                userProjectHistory.project.name,
+                                Expressions.stringTemplate("DATE_FORMAT(userProjectHistory.updateDate, '%Y %b %d %H:%i:%s')", userProjectHistory.updateDate)
+                        )
+                )
+                .from(userProjectHistory)
+                .leftJoin(userProjectHistory.project, project)
+                .leftJoin(userProjectHistory.user, user)
+                .where(userProjectHistory.user.id.eq(userId))
+                .orderBy(userProjectHistory.updateDate.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return content;
+    }
+}

--- a/src/main/java/com/example/demo/service/user/UserProjectHistoryService.java
+++ b/src/main/java/com/example/demo/service/user/UserProjectHistoryService.java
@@ -1,9 +1,13 @@
 package com.example.demo.service.user;
 
+import com.example.demo.dto.user.response.UserProjectHistoryInfoResponseDto;
 import com.example.demo.model.project.Project;
 import com.example.demo.model.user.User;
 import com.example.demo.model.user.UserProjectHistory;
+import org.springframework.data.domain.Page;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Transactional
 public interface UserProjectHistoryService {
@@ -11,4 +15,10 @@ public interface UserProjectHistoryService {
     public UserProjectHistory toUserProjectHistoryEntity(User user, Project project);
 
     public UserProjectHistory save(UserProjectHistory userProjectHistory);
+
+    // 회원 프로젝트 이력 전체 개수 조회
+    Long getUserProjectHistoryTotalCount(Long userId);
+
+    // 회원 프로젝트 이력 조회
+    List<UserProjectHistoryInfoResponseDto> getUserProjectHistoryList(Long userId, int pageNumber);
 }

--- a/src/main/java/com/example/demo/service/user/UserProjectHistoryServiceImpl.java
+++ b/src/main/java/com/example/demo/service/user/UserProjectHistoryServiceImpl.java
@@ -1,12 +1,18 @@
 package com.example.demo.service.user;
 
 import com.example.demo.constant.UserProjectHistoryStatus;
+import com.example.demo.dto.user.response.UserProjectHistoryInfoResponseDto;
 import com.example.demo.model.project.Project;
 import com.example.demo.model.user.User;
 import com.example.demo.model.user.UserProjectHistory;
 import com.example.demo.repository.user.UserProjectHistoryRepository;
 import java.time.LocalDateTime;
+import java.util.List;
+
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -29,5 +35,16 @@ public class UserProjectHistoryServiceImpl implements UserProjectHistoryService 
     @Override
     public UserProjectHistory save(UserProjectHistory userProjectHistory) {
         return userProjectHistoryRepository.save(userProjectHistory);
+    }
+
+    @Override
+    public Long getUserProjectHistoryTotalCount(Long userId) {
+        return userProjectHistoryRepository.countUserProjectHistoryByUserId(userId);
+    }
+
+    @Override
+    public List<UserProjectHistoryInfoResponseDto> getUserProjectHistoryList(Long userId, int pageNumber) {
+        PageRequest pageRequest = PageRequest.of(pageNumber - 1, 5);
+        return userProjectHistoryRepository.findAllByUserIdOrderByUpdateDateDesc(userId, pageRequest);
     }
 }


### PR DESCRIPTION
### 작업내용
- 회원 프로젝트 이력 정보를 응답하는 UserProjectHistoryInfoResponseDto 구현
- queryDsl을 활용해 회원 프로젝트 이력 갯수를 조회하는 쿼리 구현
- queryDsl을 활용해 회원 프로젝트 이력 목록을 페이징하여 조회하는 쿼리 구현, offset 방식을 사용하고 UserProjectHistoryInfoResponseDto 타입으로 데이터 응답
- UserProjectHistoryService에 회원 프로젝트 이력 갯수, 회원 프로젝트 이력 목록을 조회하는 로직 구현