### PR TITLE
[feature/220-token-reissue] 토큰 재발급 로직 구현

### DIFF
--- a/src/main/java/com/example/demo/dto/user/request/UserTokenReissueRequestDto.java
+++ b/src/main/java/com/example/demo/dto/user/request/UserTokenReissueRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.demo.dto.user.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserTokenReissueRequestDto {
+
+    private Long userId;
+}

--- a/src/main/java/com/example/demo/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/global/config/SecurityConfig.java
@@ -4,11 +4,9 @@ import com.example.demo.security.SecurityResponseHandler;
 import com.example.demo.security.custom.UserAuthenticationFailureHandler;
 import com.example.demo.security.custom.UserAuthenticationFilter;
 import com.example.demo.security.custom.UserAuthenticationSuccessHandler;
-import com.example.demo.security.jwt.JsonWebTokenAuthenticationFilter;
-import com.example.demo.security.jwt.JsonWebTokenExceptionFilter;
-import com.example.demo.security.jwt.JsonWebTokenLogoutFilter;
-import com.example.demo.security.jwt.JsonWebTokenProvider;
+import com.example.demo.security.jwt.*;
 import com.example.demo.service.token.RefreshTokenRedisService;
+import com.example.demo.service.user.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,11 +31,12 @@ import org.springframework.security.web.authentication.logout.LogoutFilter;
 public class SecurityConfig {
 
     private final JsonWebTokenProvider jsonWebTokenProvider;
-    private final RefreshTokenRedisService refreshTokenRedisService;
     private final AuthenticationConfiguration authenticationConfiguration;
     private final ObjectMapper objectMapper;
     private final CorsConfig corsConfig;
     private final SecurityResponseHandler securityResponseHandler;
+    private final RefreshTokenRedisService refreshTokenRedisService;
+    private final UserService userService;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -95,6 +94,9 @@ public class SecurityConfig {
         http.addFilterBefore(
                 new JsonWebTokenExceptionFilter(securityResponseHandler),
                 JsonWebTokenAuthenticationFilter.class);
+        http.addFilterBefore(
+                new JsonWebTokenReissueFilter(refreshTokenRedisService, userService, objectMapper, jsonWebTokenProvider, securityResponseHandler),
+                JsonWebTokenExceptionFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/example/demo/global/exception/customexception/TokenCustomException.java
+++ b/src/main/java/com/example/demo/global/exception/customexception/TokenCustomException.java
@@ -22,6 +22,15 @@ public class TokenCustomException extends CustomException {
     public static final TokenCustomException DOES_NOT_REFRESH_TOKEN =
             new TokenCustomException(TokenErrorCode.DOES_NOT_REFRESH_TOKEN);
 
+    public static final TokenCustomException INSUFFICIENT_USER_IDENTIFICATION_FOR_TOKEN_REISSUE =
+            new TokenCustomException(TokenErrorCode.INSUFFICIENT_USER_IDENTIFICATION_FOR_TOKEN_REISSUE);
+
+    public static final TokenCustomException INVALID_REFRESH_TOKEN =
+            new TokenCustomException(TokenErrorCode.INVALID_REFRESH_TOKEN);
+
+    public static final TokenCustomException REFRESH_TOKEN_NOT_FOUND =
+            new TokenCustomException(TokenErrorCode.REFRESH_TOKEN_NOT_FOUND);
+
     public TokenCustomException(TokenErrorCode tokenErrorCode) {
         super(tokenErrorCode);
     }

--- a/src/main/java/com/example/demo/global/exception/errorcode/TokenErrorCode.java
+++ b/src/main/java/com/example/demo/global/exception/errorcode/TokenErrorCode.java
@@ -12,7 +12,10 @@ public enum TokenErrorCode implements ErrorCode {
     WRONG_TYPE_TOKEN(HttpStatus.UNAUTHORIZED, "지원되지 않는 형식이나 구성의 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰 정보입니다."),
     MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, "손상된 토큰 정보입니다."),
-    DOES_NOT_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "요청 헤더 쿠키에 리프레시 토큰 정보가 존재하지 않습니다.");
+    DOES_NOT_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "요청 정보에 리프레시 토큰 정보가 존재하지 않습니다."),
+    INSUFFICIENT_USER_IDENTIFICATION_FOR_TOKEN_REISSUE(HttpStatus.BAD_REQUEST, "토큰 재발급을 위한 회원 식별 정보가 부족합니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "제공된 리프레시 토큰 정보가 올바르지 않습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "리프레시 토큰 정보가 존재하지 않습니다. 재로그인이 필요합니다.");
 
     private HttpStatus status;
     private String message;

--- a/src/main/java/com/example/demo/security/jwt/JsonWebTokenProvider.java
+++ b/src/main/java/com/example/demo/security/jwt/JsonWebTokenProvider.java
@@ -146,20 +146,16 @@ public class JsonWebTokenProvider {
         return null;
     }
 
-    // Request Header 에서 Refresh Token 정보 추출
-    public String resolveRefreshToken(HttpServletRequest request) {
+    // Request Header 에서 Refresh Cookie 정보 추출
+    public Cookie resolveRefreshCookie(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
-        String bearerToken =
-                Arrays.stream(cookies)
-                        .filter(cookie -> cookie.getName().equals(REFRESH_HEADER))
-                        .findFirst()
-                        .orElseThrow(() -> TokenCustomException.DOES_NOT_REFRESH_TOKEN)
-                        .getValue();
-
-        if (StringUtils.hasText(bearerToken)) {
-            return bearerToken;
+        if(cookies == null) {
+            throw TokenCustomException.DOES_NOT_REFRESH_TOKEN;
         }
 
-        return null;
+        return Arrays.stream(cookies)
+                        .filter(cookie -> cookie.getName().equals(REFRESH_HEADER))
+                        .findFirst()
+                        .orElseThrow(() -> TokenCustomException.DOES_NOT_REFRESH_TOKEN);
     }
 }

--- a/src/main/java/com/example/demo/security/jwt/JsonWebTokenReissueFilter.java
+++ b/src/main/java/com/example/demo/security/jwt/JsonWebTokenReissueFilter.java
@@ -1,0 +1,178 @@
+package com.example.demo.security.jwt;
+
+import com.example.demo.dto.common.ResponseDto;
+import com.example.demo.dto.user.request.UserTokenReissueRequestDto;
+import com.example.demo.global.exception.customexception.CommonCustomException;
+import com.example.demo.global.exception.customexception.CustomException;
+import com.example.demo.global.exception.customexception.TokenCustomException;
+import com.example.demo.global.exception.errorcode.ErrorCode;
+import com.example.demo.security.SecurityResponseHandler;
+import com.example.demo.security.custom.PrincipalDetails;
+import com.example.demo.service.token.RefreshTokenRedisService;
+import com.example.demo.service.user.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ *  AccessToken 만료 시, RefreshToken 값으로 AccessToken 재발급 로직을 담당하는 필터
+ */
+@RequiredArgsConstructor
+public class JsonWebTokenReissueFilter extends OncePerRequestFilter {
+
+    private static final String TOKEN_REISSUE_REQUEST_URI = "/api/user/token-reissue";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_TOKEN_PREFIX = "Bearer ";
+    private final RefreshTokenRedisService refreshTokenRedisService;
+    private final UserService userService;
+    private final ObjectMapper objectMapper;
+    private final JsonWebTokenProvider jsonWebTokenProvider;
+    private final SecurityResponseHandler securityResponseHandler;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        if(isTokenReissueRequest(request)) {
+            handleTokenReissue(request, response);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    // 토큰 재발급 요청 확인
+    private boolean isTokenReissueRequest(HttpServletRequest request) {
+        return request.getServletPath().equals(TOKEN_REISSUE_REQUEST_URI)
+                && request.getMethod().equals(HttpMethod.POST.name());
+    }
+
+    // 토큰 재발급 로직
+    private void handleTokenReissue(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        try {
+            // 요청 데이터에서 회원 ID(PK) 추출
+            Long userId = parseUserId(request);
+            // 요청 데이터에서 RefreshToken 정보 추출
+            String requestRefreshToken = parseRefreshToken(request);
+
+            // 회원 ID(PK)로 회원 정보를 조회하고 커스텀 회원 인증 정보로 가져오기
+            PrincipalDetails principalDetails = getUserByUserIdToPrincipalDetails(userId);
+
+            // RefreshToken 검증
+            validationRefreshToken(userId, requestRefreshToken);
+
+            // 토큰 재발급
+            JsonWebTokenDto newTokens = jsonWebTokenProvider.generateToken(principalDetails);
+
+            // RefreshToken 갱신
+            renewRefreshToken(userId, newTokens.getRefreshToken());
+
+            // ResponseHeader 토큰 셋팅
+            setTokensInResponseHeader(request, response, newTokens);
+
+            // 성공 응답
+            successTokenReissueResponse(response);
+        } catch (CustomException customException) {
+            // 실패 응답
+            failTokenReissueResponse(response, customException.getErrorCode());
+        }
+    }
+
+    // 요청 데이터에서 회원 ID(PK) 추출
+    private Long parseUserId(HttpServletRequest request) throws IOException {
+        try {
+            UserTokenReissueRequestDto tokenReissueRequestData = objectMapper.readValue(request.getInputStream(), UserTokenReissueRequestDto.class);
+
+            // Request 정보가 존재하지 않는 경우, 토큰 재발급을 위한 회원 식별 정보 부족 예외처리
+            if(Objects.isNull(tokenReissueRequestData) || tokenReissueRequestData.getUserId() == null) {
+                throw TokenCustomException.INSUFFICIENT_USER_IDENTIFICATION_FOR_TOKEN_REISSUE;
+            }
+
+            return tokenReissueRequestData.getUserId();
+
+        } catch (MismatchedInputException e) {
+            throw CommonCustomException.INVALID_INPUT_VALUE;
+        }
+    }
+
+    // 요청 데이터에서 RefreshToken 추출
+    private String parseRefreshToken(HttpServletRequest request) {
+        String refreshToken = jsonWebTokenProvider.resolveRefreshCookie(request).getValue();
+
+        // 추출한 RefreshToken 정보가 null 또는 길이가 0인 경우, 토큰 재발급을 위한 회원 식별 정보 부족 예외처리
+        if(!StringUtils.hasText(refreshToken)) {
+            throw TokenCustomException.INSUFFICIENT_USER_IDENTIFICATION_FOR_TOKEN_REISSUE;
+        }
+
+        return refreshToken;
+    }
+
+    // RefreshToken 검증
+    private void validationRefreshToken(Long userId, String requestRefreshToken) {
+        // 회원 RefreshToken 조회
+        String storedRefreshToken = refreshTokenRedisService.get(userId);
+
+        // 회원의 RefreshToken 정보가 존재하지 않는 경우, 예외 처리
+        if(storedRefreshToken == null) {
+            throw TokenCustomException.REFRESH_TOKEN_NOT_FOUND;
+        }
+
+        // 요청한 RefreshToken, 저장된 회원의 RefreshToken 이 다른 경우, RefreshToken 예외 처리
+        if(!requestRefreshToken.equals(storedRefreshToken)) {
+            throw TokenCustomException.INVALID_REFRESH_TOKEN;
+        }
+    }
+
+    // 회원 정보를 커스텀 회원 정보 객체로 조회
+    private PrincipalDetails getUserByUserIdToPrincipalDetails(Long userId) {
+        return new PrincipalDetails(userService.findById(userId));
+    }
+
+    // RefreshToken 갱신
+    private void renewRefreshToken(Long userId, String newRefreshToken) {
+        // 기존 RefreshToken 삭제
+        refreshTokenRedisService.delete(userId);
+
+        // 새로 발급받은 RefreshToken 추가
+        refreshTokenRedisService.save(userId, newRefreshToken);
+    }
+
+    // ResponseHeader 토큰 셋팅
+    private void setTokensInResponseHeader(HttpServletRequest request, HttpServletResponse response, JsonWebTokenDto tokens) {
+        // RefreshToken 업데이트
+        response.addCookie(updateRefreshTokenCookie(request, tokens.getRefreshToken()));
+        // AccessToken 셋팅
+        response.setHeader(AUTHORIZATION_HEADER, BEARER_TOKEN_PREFIX + tokens.getAccessToken());
+    }
+
+    // RefreshTokenCookie 업데이트
+    private Cookie updateRefreshTokenCookie(HttpServletRequest request, String newRefreshToken) {
+        Cookie refreshCookie = jsonWebTokenProvider.resolveRefreshCookie(request);
+
+        refreshCookie.setValue(newRefreshToken);
+        refreshCookie.setHttpOnly(true);
+        refreshCookie.setPath("/");
+
+        return refreshCookie;
+    }
+
+    // 토큰 재발급 성공 응답
+    private void successTokenReissueResponse(HttpServletResponse response) throws IOException{
+        securityResponseHandler.sendResponse(response, HttpStatus.OK, ResponseDto.success("토큰 재발급이 완료되었습니다."));
+    }
+
+    // 토큰 재발급 실패 응답
+    private void failTokenReissueResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException{
+        securityResponseHandler.sendResponse(response, errorCode.getStatus(), ResponseDto.fail(errorCode.getMessage()));
+    }
+}


### PR DESCRIPTION
### 작업내용
- AccessToken이 만료되면 RefreshToken으로 새로운 AccessToken과 RefreshToken을 재발급하는 로직 구현 (RTR 적용)
- JsonWebTokenReissueFilter에 토큰을 재발급하는 로직을 구현해 필터단에서 처리되도록 구현
- 토큰 재발급을 위해서 회원의 ID(PK) 정보가 필요한데 AccessToken이 만료되면 AccessToken에서 회원 정보(ID(PK), email)를 추출할 수 없고, 현재 서비스에서는 RefreshToken에 회원 정보를 담고 있지 않기 때문에 클라이언트로부터 JSON 타입의 회원 ID(PK) 정보를 요청받도록 구현
- 토큰 재발급 요청 시, 클라이언트로부터 회원의 ID(PK)와 RefreshToken 정보를 요청받아 회원 검증과 RefreshToken 검증 절차를 수행하여 문제 발생 시 적절한 예외 처리를 진행하고 문제가 없을 경우 새로운 AccessToken과 RefreshToken을 발급해 토큰을 갱신하고 클라이언트에게 응답하도록 구현


### 연관이슈
#220 