### PR TITLE
[feature/fix-get-my-info] 내 정보 조회 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/dto/user/response/UserMyInfoResponseDto.java
+++ b/src/main/java/com/example/demo/dto/user/response/UserMyInfoResponseDto.java
@@ -29,8 +29,6 @@ public class UserMyInfoResponseDto {
 
     private long projectHistoryTotalCount;
 
-    private List<UserProjectHistoryInfoResponseDto> projectHistoryList;
-
     private String createDate;
 
     private String updateDate;
@@ -45,7 +43,6 @@ public class UserMyInfoResponseDto {
             PositionInfoResponseDto position,
             List<TechnologyStackInfoResponseDto> techStacks,
             long projectHistoryTotalCount,
-            List<UserProjectHistoryInfoResponseDto> projectHistoryList,
             String createDate,
             String updateDate) {
         return UserMyInfoResponseDto.builder()
@@ -58,7 +55,6 @@ public class UserMyInfoResponseDto {
                 .position(position)
                 .techStacks(techStacks)
                 .projectHistoryTotalCount(projectHistoryTotalCount)
-                .projectHistoryList(projectHistoryList)
                 .createDate(createDate)
                 .updateDate(updateDate)
                 .build();

--- a/src/main/java/com/example/demo/service/user/UserFacade.java
+++ b/src/main/java/com/example/demo/service/user/UserFacade.java
@@ -243,14 +243,11 @@ public class UserFacade {
                 .collect(Collectors.toList());
         // 회원 프로젝트 이력 개수
         long projectHistoryTotalCount = userProjectHistoryService.getUserProjectHistoryTotalCount(currentUser.getId());
-        // 회원 프로젝트 이력 목록 정보 응답 DTO
-        List<UserProjectHistoryInfoResponseDto> projectHistoryListInfo = userProjectHistoryService.getUserProjectHistoryList(currentUser.getId(), 1);
-
 
         // 내 정보 응답 DTO 생성
         UserMyInfoResponseDto myInfoResponse = UserMyInfoResponseDto.of(currentUser.getId(), currentUser.getEmail(), currentUser.getNickname(),
                 currentUser.getProfileImgSrc(), trustScore.getScore(), trustGradeInfo, positionInfo, techStacksInfo, projectHistoryTotalCount,
-                projectHistoryListInfo, DateTimeConverter.toStringConvert(currentUser.getCreateDate()), DateTimeConverter.toStringConvert(currentUser.getUpdateDate()));
+                DateTimeConverter.toStringConvert(currentUser.getCreateDate()), DateTimeConverter.toStringConvert(currentUser.getUpdateDate()));
 
         return ResponseDto.success("내 정보 조회가 완료되었습니다.", myInfoResponse);
     }


### PR DESCRIPTION
### 작업내용
- 회원의 프로젝트 이력 목록은 별도의 api 요청을 통해 조회하기로 결정하여 내 정보 조회 시 회원의 프로젝트 이력 목록을 함께 응답하지 않도록 변경
- UserMyInfoResponseDto에서 회원 프로젝트 이력 목록 필드 제거
 