### PR TITLE
[feature/fix-update-board] 게시글 수정 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/controller/board/BoardController.java
+++ b/src/main/java/com/example/demo/controller/board/BoardController.java
@@ -53,10 +53,11 @@ public class BoardController {
 
     @PatchMapping("/{boardId}")
     public ResponseEntity<ResponseDto<?>> update(
+            @AuthenticationPrincipal PrincipalDetails user,
             @PathVariable("boardId") Long boardId,
             @RequestBody BoardProjectUpdateRequestDto requestDto) {
         try {
-            BoardProjectUpdateResponseDto result = boardFacade.update(boardId, requestDto);
+            BoardProjectUpdateResponseDto result = boardFacade.update(user.getId(), boardId, requestDto);
             return new ResponseEntity<>(ResponseDto.success("success", result), HttpStatus.OK);
         } catch (Exception ex) {
             ex.printStackTrace();

--- a/src/main/java/com/example/demo/global/exception/customexception/BoardCustomException.java
+++ b/src/main/java/com/example/demo/global/exception/customexception/BoardCustomException.java
@@ -7,6 +7,9 @@ public class BoardCustomException extends CustomException {
     public static final BoardCustomException NOT_FOUND_BOARD =
             new BoardCustomException(BoardErrorCode.NOT_FOUND_BOARD);
 
+    public static final BoardCustomException NO_PERMISSION_TO_EDIT_OR_DELETE =
+            new BoardCustomException(BoardErrorCode.NO_PERMISSION_TO_EDIT_OR_DELETE);
+
     public BoardCustomException(BoardErrorCode boardErrorCode) {
         super(boardErrorCode);
     }

--- a/src/main/java/com/example/demo/global/exception/errorcode/BoardErrorCode.java
+++ b/src/main/java/com/example/demo/global/exception/errorcode/BoardErrorCode.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
 public enum BoardErrorCode implements ErrorCode {
-    NOT_FOUND_BOARD(HttpStatus.NOT_FOUND, "해당 게시글이 존재하지 않습니다.");
+    NOT_FOUND_BOARD(HttpStatus.NOT_FOUND, "해당 게시글이 존재하지 않습니다."),
+    NO_PERMISSION_TO_EDIT_OR_DELETE(HttpStatus.FORBIDDEN, "해당 게시글을 수정 및 삭제할 권한이 존재하지 않습니다.");
 
     private HttpStatus status;
     private String message;

--- a/src/main/java/com/example/demo/model/board/Board.java
+++ b/src/main/java/com/example/demo/model/board/Board.java
@@ -2,6 +2,7 @@ package com.example.demo.model.board;
 
 import com.example.demo.dto.board.request.BoardUpdateRequestDto;
 import com.example.demo.global.common.BaseTimeEntity;
+import com.example.demo.global.exception.customexception.BoardCustomException;
 import com.example.demo.model.project.Project;
 import com.example.demo.model.user.User;
 import java.util.ArrayList;
@@ -58,6 +59,13 @@ public class Board extends BaseTimeEntity {
         this.completeStatus = completeStatus;
         this.user = user;
         this.contact = contact;
+    }
+
+    // 게시글 작성자 검증
+    public void validationUser(User user) {
+        if(!this.user.equals(user)) {
+            throw BoardCustomException.NO_PERMISSION_TO_EDIT_OR_DELETE;
+        }
     }
 
     public void updateBoard(BoardUpdateRequestDto dto) {

--- a/src/main/java/com/example/demo/service/board/BoardFacade.java
+++ b/src/main/java/com/example/demo/service/board/BoardFacade.java
@@ -124,10 +124,14 @@ public class BoardFacade {
      * @param dto
      * @return
      */
-    public BoardProjectUpdateResponseDto update(Long boardId, BoardProjectUpdateRequestDto dto) {
+    public BoardProjectUpdateResponseDto update(Long userId, Long boardId, BoardProjectUpdateRequestDto dto) {
+        User tempUser = userService.findById(userId); // 나중에 Security로 고쳐야 함.
         Board board = boardService.findById(boardId);
+
+        // 게시글 작성자 검증
+        board.validationUser(tempUser);
+
         Project project = board.getProject();
-        User tempUser = userService.findById(1L); // 나중에 Security로 고쳐야 함.
 
         TrustGrade trustGrade =
                 trustGradeService.getTrustGradeById(dto.getProject().getTrustGradeId());


### PR DESCRIPTION
### 작업내용
- 게시글 수정 로직에서 로그인한 회원의 인증 정보를 가져오기 위해 AuthenticationPricipal 어노테이션 등록
- Board 엔티티에 조작을 요청한 회원과 해당 게시글을 작성한 회원이 같은지 검증하는 로직 추가
- 만약 다른 경우 응답할 NO_PERMISSION_TO_EDIT_OR_DELETE 에러코드 및 커스텀 예외 추가