### PR TITLE
[feature/fix-delete-board] 게시글 삭제 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/controller/board/BoardController.java
+++ b/src/main/java/com/example/demo/controller/board/BoardController.java
@@ -66,8 +66,8 @@ public class BoardController {
     }
 
     @DeleteMapping("/{boardId}")
-    public ResponseEntity<ResponseDto<?>> delete(@PathVariable("boardId") Long boardId) {
-        boardService.delete(boardId);
+    public ResponseEntity<ResponseDto<?>> delete(@AuthenticationPrincipal PrincipalDetails user, @PathVariable("boardId") Long boardId) {
+        boardFacade.deleteBoard(user.getId(), boardId);
         return new ResponseEntity<>(ResponseDto.success("success", null), HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/example/demo/service/board/BoardFacade.java
+++ b/src/main/java/com/example/demo/service/board/BoardFacade.java
@@ -168,4 +168,15 @@ public class BoardFacade {
 
         return new BoardProjectUpdateResponseDto(boardUpdateResponseDto, projectUpdateResponseDto);
     }
+
+    @Transactional
+    public void deleteBoard(Long userId, Long boardId) {
+        User tempUser = userService.findById(userId);
+        Board board = boardService.findById(boardId);
+
+        // 게시글 작성자 검증
+        board.validationUser(tempUser);
+
+        boardService.delete(board);
+    }
 }

--- a/src/main/java/com/example/demo/service/board/BoardService.java
+++ b/src/main/java/com/example/demo/service/board/BoardService.java
@@ -20,5 +20,5 @@ public interface BoardService {
 
     public BoardTotalDetailResponseDto getDetail(Long boardId);
 
-    public void delete(Long boardId);
+    public void delete(Board board);
 }

--- a/src/main/java/com/example/demo/service/board/BoardServiceImpl.java
+++ b/src/main/java/com/example/demo/service/board/BoardServiceImpl.java
@@ -108,10 +108,9 @@ public class BoardServiceImpl implements BoardService {
     /**
      * 게시글 삭제
      *
-     * @param boardId
+     * @param board
      */
-    public void delete(Long boardId) {
-        Board board = findById(boardId);
+    public void delete(Board board) {
         boardRepository.delete(board);
     }
 }


### PR DESCRIPTION
### 작업내용
- 게시글 삭제 로직에서 로그인한 회원의 인증 정보를 가져오기 위해 AuthenticationPricipal 어노테이션 등록
- 게시글 삭제 시 삭제를 요청한 회원을 검증하기 위해 BoardFacade에 게시글을 삭제하는 로직을 새로 구현
- BoardFacade의 deleteBoard() 로직을 통해 요청한 회원을 검증하고 검증이 완료된 후, 게시글을 삭제하도록 수정