### PR TITLE
[feature/fix-security-authorization-uri-pattern] 인가 허용 URI 패턴 변경

### DIFF
--- a/src/main/java/com/example/demo/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/global/config/SecurityConfig.java
@@ -85,7 +85,7 @@ public class SecurityConfig {
                 .disable()
                 .authorizeRequests()
                 .antMatchers("/api/admin/**").hasRole("ADMIN")
-                .antMatchers("/api/public/**").permitAll()
+                .antMatchers("/**/public").permitAll()
                 .anyRequest().authenticated();
 
         http.addFilterAfter(userAuthenticationFilter(), LogoutFilter.class);


### PR DESCRIPTION
### 작업내용
- URI에서 각 도메인별 의미 전달을 명확하게 하기 위해 로그인 없이 접근이 가능한 요청의 URI 패턴을 기존 /api/public/** 에서 /**/public으로 변경