### PR TITLE
[feature/240-fix-public-access] 모든 접근을 허용하는 URI 정보 수정

### DIFF
--- a/src/main/java/com/example/demo/controller/board/BoardController.java
+++ b/src/main/java/com/example/demo/controller/board/BoardController.java
@@ -29,7 +29,7 @@ public class BoardController {
     private final BoardService boardService;
     private final BoardFacade boardFacade;
 
-    @PostMapping(value = {"/search", "/search/{page}"})
+    @PostMapping(value = {"/search/public", "/search/{page}/public"})
     public ResponseEntity<ResponseDto<?>> search(
             @RequestBody BoardSearchRequestDto dto, @PathVariable("page") Optional<Integer> page) {
         Pageable pageable = PageRequest.of(page.isPresent() ? page.get() : 0, 5);
@@ -37,7 +37,7 @@ public class BoardController {
         return new ResponseEntity<>(ResponseDto.success("success", result), HttpStatus.OK);
     }
 
-    @GetMapping("/{boardId}")
+    @GetMapping("/{boardId}/public")
     public ResponseEntity<ResponseDto<?>> getDetail(@PathVariable("boardId") Long boardId) {
         BoardTotalDetailResponseDto result = boardService.getDetail(boardId);
         return new ResponseEntity<>(ResponseDto.success("success", result), HttpStatus.OK);

--- a/src/main/java/com/example/demo/controller/position/PositionController.java
+++ b/src/main/java/com/example/demo/controller/position/PositionController.java
@@ -15,7 +15,7 @@ public class PositionController {
     private final PositionService positionService;
 
     // 포지션 목록 조회 요청
-    @GetMapping("/api/position-list")
+    @GetMapping("/api/position-list/public")
     public ResponseEntity<ResponseDto<?>> getPositionList() {
         return ResponseEntity.status(HttpStatus.OK).body(positionService.getPositionList());
     }

--- a/src/main/java/com/example/demo/controller/technology_stack/TechnologyStackController.java
+++ b/src/main/java/com/example/demo/controller/technology_stack/TechnologyStackController.java
@@ -15,7 +15,7 @@ public class TechnologyStackController {
     private final TechnologyStackService technologyStackService;
 
     // 기술스택 목록 조회 요청
-    @GetMapping("/api/technology-stack-list")
+    @GetMapping("/api/technology-stack-list/public")
     public ResponseEntity<ResponseDto<?>> getTechnologyStackList() {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(technologyStackService.getTechnologyStackList());

--- a/src/main/java/com/example/demo/controller/user/UserController.java
+++ b/src/main/java/com/example/demo/controller/user/UserController.java
@@ -22,19 +22,19 @@ public class UserController {
     private final UserService userService;
 
     // 이메일 중복확인 요청
-    @GetMapping("/check-email/{email}")
+    @GetMapping("/check-email/{email}/public")
     public ResponseEntity<ResponseDto<?>> checkEmail(@PathVariable String email) {
         return ResponseEntity.status(HttpStatus.OK).body(userService.checkEmail(email));
     }
 
     // 닉네임 중복확인 요청
-    @GetMapping("/check-nickname/{nickname}")
+    @GetMapping("/check-nickname/{nickname}/public")
     public ResponseEntity<ResponseDto<?>> checkNickname(@PathVariable String nickname) {
         return ResponseEntity.status(HttpStatus.OK).body(userService.checkNickname(nickname));
     }
 
     // 회원가입
-    @PostMapping()
+    @PostMapping("/public")
     public ResponseEntity<ResponseDto<?>> signup(
             @Valid @RequestBody UserCreateRequestDto createRequest) {
         return ResponseEntity.status(HttpStatus.CREATED).body(userFacade.createUser(createRequest));

--- a/src/main/java/com/example/demo/security/custom/UserAuthenticationFilter.java
+++ b/src/main/java/com/example/demo/security/custom/UserAuthenticationFilter.java
@@ -20,14 +20,14 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 public class UserAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
 
     // 로그인 요청 URL
-    private static final String DEFAULT_LOGIN_REQUEST_URL = "/api/user/login";
+    private static final String DEFAULT_LOGIN_REQUEST_URI = "/api/user/login/public";
 
     // 로그인 HTTP 메소드
     private static final String HTTP_METHOD = "POST";
 
     // "/api/user/login" + POST로 온 요청에 매칭
     private static final AntPathRequestMatcher DEFAULT_LOGIN_PATH_REQUEST_MATCHER =
-            new AntPathRequestMatcher(DEFAULT_LOGIN_REQUEST_URL, HTTP_METHOD);
+            new AntPathRequestMatcher(DEFAULT_LOGIN_REQUEST_URI, HTTP_METHOD);
 
     private final ObjectMapper objectMapper;
 

--- a/src/main/java/com/example/demo/security/jwt/JsonWebTokenAuthenticationFilter.java
+++ b/src/main/java/com/example/demo/security/jwt/JsonWebTokenAuthenticationFilter.java
@@ -15,7 +15,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Slf4j
 public class JsonWebTokenAuthenticationFilter extends OncePerRequestFilter {
 
-    private static final List<String> PERMIT_URI = List.of("/api/user/login");
     private JsonWebTokenProvider jsonWebTokenProvider;
 
     public JsonWebTokenAuthenticationFilter(JsonWebTokenProvider jsonWebTokenProvider) {
@@ -26,12 +25,11 @@ public class JsonWebTokenAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(
             HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        String requestUri = request.getRequestURI();
         String accessToken = jsonWebTokenProvider.resolveAccessToken(request);
         log.info("AccessToken : {}", accessToken);
 
         // 요청 URI 확인 및 토큰 검증
-        if (!PERMIT_URI.contains(requestUri) && jsonWebTokenProvider.validateToken(accessToken)) {
+        if(!isPublicEndpoint(request.getRequestURI()) && jsonWebTokenProvider.validateToken(accessToken)) {
             // 토큰에 담긴 회원정보를 추출해 시큐리티에서 사용할 인증 객체 반환
             Authentication authentication = jsonWebTokenProvider.getAuthentication(accessToken);
 
@@ -40,5 +38,10 @@ public class JsonWebTokenAuthenticationFilter extends OncePerRequestFilter {
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    // 요청한 URI가 public URI인지 확인
+    private boolean isPublicEndpoint(String requestUri) {
+        return requestUri.endsWith("/public");
     }
 }


### PR DESCRIPTION
### 작업내용
- 별도의 권한, 인증과정 없이 모든 접근이 허용된 URI 매핑 정보 수정
- 회원가입, 로그인, 이메일 중복확인, 닉네임 중복확인, 게시글 검색, 게시글 상세 조회, 직무 목록 조회, 기술스택 목록 조회 요청 URI 매핑 정보 뒤에 /public 추가
- JsonWebToken을 인증하는 로직에서 요청한 URI가 모든 접근이 허용된 URI 인지 확인하는 로직 수정


### 연관이슈
#240 