### PR TITLE
[feature/240-fix-start-end-date-type] 시작날짜, 종료날짜 데이터 타입 변경

### DIFF
--- a/src/main/java/com/example/demo/dto/milestone/request/MileStoneUpdateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/milestone/request/MileStoneUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package com.example.demo.dto.milestone.request;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,6 +9,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class MileStoneUpdateRequestDto {
     private String content;
-    private LocalDateTime startDate;
-    private LocalDateTime endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
 }

--- a/src/main/java/com/example/demo/dto/milestone/request/MilestoneCreateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/milestone/request/MilestoneCreateRequestDto.java
@@ -2,6 +2,8 @@ package com.example.demo.dto.milestone.request;
 
 import com.example.demo.model.milestone.Milestone;
 import com.example.demo.model.project.Project;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,8 +12,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public class MilestoneCreateRequestDto {
     private String content;
-    private LocalDateTime startDate;
-    private LocalDateTime endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
 
     public Milestone toMileStoneEntity(Project project) {
         return Milestone.builder()

--- a/src/main/java/com/example/demo/dto/milestone/request/MilestoneUpdateDateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/milestone/request/MilestoneUpdateDateRequestDto.java
@@ -1,5 +1,6 @@
 package com.example.demo.dto.milestone.request;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -7,6 +8,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class MilestoneUpdateDateRequestDto {
-    private LocalDateTime startDate;
-    private LocalDateTime endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
 }

--- a/src/main/java/com/example/demo/dto/milestone/response/MilestoneCreateResponseDto.java
+++ b/src/main/java/com/example/demo/dto/milestone/response/MilestoneCreateResponseDto.java
@@ -1,6 +1,8 @@
 package com.example.demo.dto.milestone;
 
 import com.example.demo.model.milestone.Milestone;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,8 +13,8 @@ public class MilestoneCreateResponseDto {
     private Long mileStoneId;
     private Long projectId;
     private String content;
-    private LocalDateTime startDate;
-    private LocalDateTime endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
     private boolean expireStatus;
     private boolean completeStatus;
     private LocalDateTime createDate;

--- a/src/main/java/com/example/demo/dto/milestone/response/MilestoneReadResponseDto.java
+++ b/src/main/java/com/example/demo/dto/milestone/response/MilestoneReadResponseDto.java
@@ -1,6 +1,8 @@
 package com.example.demo.dto.milestone.response;
 
 import com.example.demo.model.milestone.Milestone;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,8 +13,8 @@ public class MilestoneReadResponseDto {
     private Long mileStoneId;
     private Long projectId;
     private String content;
-    private LocalDateTime startDate;
-    private LocalDateTime endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
     private boolean expireStatus;
     private boolean completeStatus;
     private LocalDateTime createDate;

--- a/src/main/java/com/example/demo/dto/project/request/ProjectCreateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/project/request/ProjectCreateRequestDto.java
@@ -5,6 +5,8 @@ import static com.example.demo.constant.ProjectStatus.RECRUITING;
 import com.example.demo.model.project.Project;
 import com.example.demo.model.trust_grade.TrustGrade;
 import com.example.demo.model.user.User;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import javax.validation.constraints.NotBlank;
@@ -28,10 +30,10 @@ public class ProjectCreateRequestDto {
     private int crewNumber;
 
     @NotBlank(message = "시작날짜는 필수 입력 값입니다.")
-    private LocalDateTime startDate;
+    private LocalDate startDate;
 
     @NotBlank(message = "종료날짜는 필수 입력 값입니다.")
-    private LocalDateTime endDate;
+    private LocalDate endDate;
 
     @NotBlank(message = "모집분야는 필수 입력 값입니다.")
     private List<Long> technologyIds;

--- a/src/main/java/com/example/demo/dto/project/request/ProjectUpdateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/project/request/ProjectUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package com.example.demo.dto.project.request;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import javax.validation.constraints.NotBlank;
@@ -24,10 +25,10 @@ public class ProjectUpdateRequestDto {
     private int crewNumber;
 
     @NotBlank(message = "시작날짜는 필수 입력 값입니다.")
-    private LocalDateTime startDate;
+    private LocalDate startDate;
 
     @NotBlank(message = "종료날짜는 필수 입력 값입니다.")
-    private LocalDateTime endDate;
+    private LocalDate endDate;
 
     @NotBlank(message = "모집분야는 필수 입력 값입니다.")
     private List<Long> technologyIds;

--- a/src/main/java/com/example/demo/dto/project/response/ProjectCreateResponseDto.java
+++ b/src/main/java/com/example/demo/dto/project/response/ProjectCreateResponseDto.java
@@ -2,6 +2,8 @@ package com.example.demo.dto.project.response;
 
 import com.example.demo.constant.ProjectStatus;
 import com.example.demo.model.project.Project;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,8 +17,8 @@ public class ProjectCreateResponseDto {
     private long userId;
     private ProjectStatus status;
     private int crewNumber;
-    private LocalDateTime startDate;
-    private LocalDateTime endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
     private LocalDateTime createDate;
     private LocalDateTime updateDate;
 

--- a/src/main/java/com/example/demo/dto/project/response/ProjectDetailResponseDto.java
+++ b/src/main/java/com/example/demo/dto/project/response/ProjectDetailResponseDto.java
@@ -5,6 +5,8 @@ import com.example.demo.dto.technology_stack.response.TechnologyStackInfoRespons
 import com.example.demo.dto.trust_grade.response.TrustGradeResponseDto;
 import com.example.demo.dto.user.response.UserProjectResponseDto;
 import com.example.demo.model.project.Project;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
@@ -20,8 +22,8 @@ public class ProjectDetailResponseDto {
     private UserProjectResponseDto user;
     private ProjectStatus status;
     private int crewNumber;
-    private LocalDateTime startDate;
-    private LocalDateTime endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
     private LocalDateTime createDate;
     private LocalDateTime updateDate;
     private List<TechnologyStackInfoResponseDto> technologyStacks;

--- a/src/main/java/com/example/demo/dto/project/response/ProjectMeResponseDto.java
+++ b/src/main/java/com/example/demo/dto/project/response/ProjectMeResponseDto.java
@@ -4,6 +4,8 @@ import com.example.demo.constant.ProjectStatus;
 import com.example.demo.dto.projectmember.response.MyProjectMemberResponseDto;
 import com.example.demo.dto.trust_grade.response.TrustGradeResponseDto;
 import com.example.demo.model.project.Project;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
@@ -19,8 +21,8 @@ public class ProjectMeResponseDto {
     private List<MyProjectMemberResponseDto> members;
     private ProjectStatus status;
     private int crewNumber;
-    private LocalDateTime startDate;
-    private LocalDateTime endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
     private LocalDateTime createDate;
     private LocalDateTime updateDate;
 

--- a/src/main/java/com/example/demo/dto/project/response/ProjectSearchResponseDto.java
+++ b/src/main/java/com/example/demo/dto/project/response/ProjectSearchResponseDto.java
@@ -3,6 +3,8 @@ package com.example.demo.dto.project.response;
 import com.example.demo.dto.technology_stack.response.TechnologyStackInfoResponseDto;
 import com.example.demo.dto.trust_grade.response.TrustGradeResponseDto;
 import com.example.demo.model.project.Project;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
@@ -15,8 +17,8 @@ public class ProjectSearchResponseDto {
     private String name;
     private String subject;
     private TrustGradeResponseDto trustGrade;
-    private LocalDateTime startDate;
-    private LocalDateTime endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
     private List<TechnologyStackInfoResponseDto> technologyStacks;
 
     public static ProjectSearchResponseDto of(

--- a/src/main/java/com/example/demo/dto/project/response/ProjectSpecificDetailResponseDto.java
+++ b/src/main/java/com/example/demo/dto/project/response/ProjectSpecificDetailResponseDto.java
@@ -3,6 +3,8 @@ package com.example.demo.dto.project.response;
 import com.example.demo.constant.ProjectStatus;
 import com.example.demo.dto.trust_grade.response.TrustGradeResponseDto;
 import com.example.demo.model.project.Project;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,8 +18,8 @@ public class ProjectSpecificDetailResponseDto {
     private TrustGradeResponseDto trustGrade;
     private ProjectStatus status;
     private int crewNumber;
-    private LocalDateTime startDate;
-    private LocalDateTime endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
     private LocalDateTime createDate;
     private LocalDateTime updateDate;
 

--- a/src/main/java/com/example/demo/dto/project/response/ProjectUpdateResponseDto.java
+++ b/src/main/java/com/example/demo/dto/project/response/ProjectUpdateResponseDto.java
@@ -2,6 +2,8 @@ package com.example.demo.dto.project.response;
 
 import com.example.demo.constant.ProjectStatus;
 import com.example.demo.model.project.Project;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,8 +18,8 @@ public class ProjectUpdateResponseDto {
     private long userId;
     private ProjectStatus status;
     private int crewNumber;
-    private LocalDateTime startDate;
-    private LocalDateTime endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
     private LocalDateTime createDate;
     private LocalDateTime updateDate;
 

--- a/src/main/java/com/example/demo/dto/work/request/WorkCreateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/work/request/WorkCreateRequestDto.java
@@ -5,6 +5,8 @@ import com.example.demo.model.project.Project;
 import com.example.demo.model.project.ProjectMember;
 import com.example.demo.model.user.User;
 import com.example.demo.model.work.Work;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,8 +15,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public class WorkCreateRequestDto {
     private String content;
-    private LocalDateTime startDate;
-    private LocalDateTime endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
     private Long assignedUserId;
 
     public Work toWorkEntity(

--- a/src/main/java/com/example/demo/dto/work/request/WorkReadResponseDto.java
+++ b/src/main/java/com/example/demo/dto/work/request/WorkReadResponseDto.java
@@ -1,6 +1,8 @@
 package com.example.demo.dto.work.request;
 
 import com.example.demo.model.work.Work;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,8 +16,8 @@ public class WorkReadResponseDto {
     private Long assignedUserId;
     private Long lastModifiedMember;
     private String content;
-    private LocalDateTime startDate;
-    private LocalDateTime endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
     private boolean expireStatus;
     private boolean completeStauts;
 

--- a/src/main/java/com/example/demo/dto/work/request/WorkUpdateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/work/request/WorkUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package com.example.demo.dto.work.request;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,6 +9,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class WorkUpdateRequestDto {
     private String content;
-    private LocalDateTime startDate;
-    private LocalDateTime endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
 }

--- a/src/main/java/com/example/demo/dto/work/response/WorkProjectDetailResponseDto.java
+++ b/src/main/java/com/example/demo/dto/work/response/WorkProjectDetailResponseDto.java
@@ -3,6 +3,8 @@ package com.example.demo.dto.work.response;
 import com.example.demo.dto.user.response.UserProjectDetailResponseDto;
 import com.example.demo.model.project.ProjectMember;
 import com.example.demo.model.work.Work;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,8 +18,8 @@ public class WorkProjectDetailResponseDto {
     private String workContent;
     private Boolean expireStatus;
     private Boolean completeStatus;
-    private LocalDateTime startDate;
-    private LocalDateTime endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
     private LocalDateTime createDate;
     private LocalDateTime updateDate;
 

--- a/src/main/java/com/example/demo/model/milestone/Milestone.java
+++ b/src/main/java/com/example/demo/model/milestone/Milestone.java
@@ -5,6 +5,8 @@ import com.example.demo.dto.milestone.request.MilestoneUpdateContentRequestDto;
 import com.example.demo.dto.milestone.request.MilestoneUpdateDateRequestDto;
 import com.example.demo.global.common.BaseTimeEntity;
 import com.example.demo.model.project.Project;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import javax.persistence.*;
 import lombok.AccessLevel;
@@ -32,10 +34,10 @@ public class Milestone extends BaseTimeEntity {
     private String content;
 
     @Column(name = "start_date")
-    private LocalDateTime startDate;
+    private LocalDate startDate;
 
     @Column(name = "end_date")
-    private LocalDateTime endDate;
+    private LocalDate endDate;
 
     @Column(name = "expire_status")
     private boolean expireStatus;
@@ -47,8 +49,8 @@ public class Milestone extends BaseTimeEntity {
     public Milestone(
             Project project,
             String content,
-            LocalDateTime startDate,
-            LocalDateTime endDate,
+            LocalDate startDate,
+            LocalDate endDate,
             boolean expireStatus,
             boolean completeStatus) {
         this.project = project;

--- a/src/main/java/com/example/demo/model/project/Project.java
+++ b/src/main/java/com/example/demo/model/project/Project.java
@@ -5,6 +5,8 @@ import com.example.demo.dto.project.request.ProjectUpdateRequestDto;
 import com.example.demo.global.common.BaseTimeEntity;
 import com.example.demo.model.trust_grade.TrustGrade;
 import com.example.demo.model.user.User;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,8 +43,8 @@ public class Project extends BaseTimeEntity {
     @Column(nullable = true)
     private int crewNumber;
 
-    private LocalDateTime startDate;
-    private LocalDateTime endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
 
     @OneToMany(mappedBy = "project", orphanRemoval = true, cascade = CascadeType.ALL)
     private List<ProjectMember> projectMembers = new ArrayList<>();
@@ -58,8 +60,8 @@ public class Project extends BaseTimeEntity {
             User user,
             ProjectStatus status,
             int crewNumber,
-            LocalDateTime startDate,
-            LocalDateTime endDate) {
+            LocalDate startDate,
+            LocalDate endDate) {
         this.name = name;
         this.subject = subject;
         this.trustGrade = trustGrade;

--- a/src/main/java/com/example/demo/model/user/UserProjectHistory.java
+++ b/src/main/java/com/example/demo/model/user/UserProjectHistory.java
@@ -3,6 +3,8 @@ package com.example.demo.model.user;
 import com.example.demo.constant.UserProjectHistoryStatus;
 import com.example.demo.global.common.BaseTimeEntity;
 import com.example.demo.model.project.Project;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import javax.persistence.*;
 import lombok.AccessLevel;
@@ -31,10 +33,10 @@ public class UserProjectHistory extends BaseTimeEntity {
     private Project project;
 
     @Column(name = "start_date")
-    private LocalDateTime startDate;
+    private LocalDate startDate;
 
     @Column(name = "end_date")
-    private LocalDateTime endDate;
+    private LocalDate endDate;
 
     @Enumerated(value = EnumType.STRING)
     private UserProjectHistoryStatus status;
@@ -43,8 +45,8 @@ public class UserProjectHistory extends BaseTimeEntity {
     public UserProjectHistory(
             User user,
             Project project,
-            LocalDateTime startDate,
-            LocalDateTime endDate,
+            LocalDate startDate,
+            LocalDate endDate,
             UserProjectHistoryStatus status) {
         this.user = user;
         this.project = project;

--- a/src/main/java/com/example/demo/model/work/Work.java
+++ b/src/main/java/com/example/demo/model/work/Work.java
@@ -8,6 +8,8 @@ import com.example.demo.model.milestone.Milestone;
 import com.example.demo.model.project.Project;
 import com.example.demo.model.project.ProjectMember;
 import com.example.demo.model.user.User;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import javax.persistence.*;
 import lombok.AccessLevel;
@@ -49,10 +51,10 @@ public class Work extends BaseTimeEntity {
     private boolean completeStatus;
 
     @Column(name = "start_date")
-    private LocalDateTime startDate;
+    private LocalDate startDate;
 
     @Column(name = "end_date")
-    private LocalDateTime endDate;
+    private LocalDate endDate;
 
     @OneToOne
     @JoinColumn(name = "project_member_id")
@@ -69,8 +71,8 @@ public class Work extends BaseTimeEntity {
             String content,
             boolean expireStatus,
             boolean completeStatus,
-            LocalDateTime startDate,
-            LocalDateTime endDate,
+            LocalDate startDate,
+            LocalDate endDate,
             ProjectMember lastModifiedMember) {
         this.project = project;
         this.milestone = milestone;

--- a/src/main/java/com/example/demo/service/user/UserProjectHistoryServiceImpl.java
+++ b/src/main/java/com/example/demo/service/user/UserProjectHistoryServiceImpl.java
@@ -6,7 +6,8 @@ import com.example.demo.model.project.Project;
 import com.example.demo.model.user.User;
 import com.example.demo.model.user.UserProjectHistory;
 import com.example.demo.repository.user.UserProjectHistoryRepository;
-import java.time.LocalDateTime;
+
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -23,7 +24,7 @@ public class UserProjectHistoryServiceImpl implements UserProjectHistoryService 
         return UserProjectHistory.builder()
                 .user(user)
                 .project(project)
-                .startDate(LocalDateTime.now())
+                .startDate(LocalDate.now())
                 .endDate(project.getEndDate())
                 .status(UserProjectHistoryStatus.PARTICIPATING)
                 .build();


### PR DESCRIPTION
### 작업내용
- 요구사항 변경으로 기존 LocalDateTime 타입의 start_date, end_date 필드를 LocalDate 타입으로 변경
- 프로젝트, 마일스톤, 업무, 사용자 프로젝트 이력 엔티티의 start_date, end_date 타입 변경
- 각 엔티티의 start_date, end_date 타입 변경에 따라 관련 dto의 시작날짜, 종료날짜 필드 타입 변경


### 연관이슈
#240 