### PR TITLE
[feature/fix-user-get-myinfo] 내 정보 조회 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/dto/user/response/UserMyInfoResponseDto.java
+++ b/src/main/java/com/example/demo/dto/user/response/UserMyInfoResponseDto.java
@@ -3,6 +3,8 @@ package com.example.demo.dto.user.response;
 import com.example.demo.dto.position.response.PositionInfoResponseDto;
 import com.example.demo.dto.technology_stack.response.TechnologyStackInfoResponseDto;
 import com.example.demo.dto.trust_grade.response.TrustGradeInfoResponseDto;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,9 +33,9 @@ public class UserMyInfoResponseDto {
 
     private long projectHistoryTotalCount;
 
-    private String createDate;
+    private LocalDateTime createDate;
 
-    private String updateDate;
+    private LocalDateTime updateDate;
 
     public static UserMyInfoResponseDto of(
             Long userId,
@@ -46,8 +48,8 @@ public class UserMyInfoResponseDto {
             PositionInfoResponseDto position,
             List<TechnologyStackInfoResponseDto> techStacks,
             long projectHistoryTotalCount,
-            String createDate,
-            String updateDate) {
+            LocalDateTime createDate,
+            LocalDateTime updateDate) {
         return UserMyInfoResponseDto.builder()
                 .userId(userId)
                 .email(email)

--- a/src/main/java/com/example/demo/service/user/UserFacade.java
+++ b/src/main/java/com/example/demo/service/user/UserFacade.java
@@ -262,7 +262,7 @@ public class UserFacade {
         // 내 정보 응답 DTO 생성
         UserMyInfoResponseDto myInfoResponse = UserMyInfoResponseDto.of(currentUser.getId(), currentUser.getEmail(), currentUser.getNickname(),
                 currentUser.getProfileImgSrc(), currentUser.getIntro(), trustScore.getScore(), trustGradeInfo, positionInfo, techStacksInfo, projectHistoryTotalCount,
-                DateTimeConverter.toStringConvert(currentUser.getCreateDate()), DateTimeConverter.toStringConvert(currentUser.getUpdateDate()));
+                currentUser.getCreateDate(), currentUser.getUpdateDate());
 
         return ResponseDto.success("내 정보 조회가 완료되었습니다.", myInfoResponse);
     }


### PR DESCRIPTION
### 작업내용
- 추후 직렬화로 공통된 날짜 데이터 응답을 처리하기 위해 내 정보 조회 응답 DTO에서 생성날짜, 수정날짜 필드의 타입을 String 타입에서 LocalDateTime 타입으로 수정