### PR TITLE
[feature/240-response-dto-localdatetime-serialization] 응답 DTO LocalDateTime 타입 데이터 직렬화 설정

### DIFF
--- a/src/main/java/com/example/demo/dto/alert/response/AlertInfoResponseDto.java
+++ b/src/main/java/com/example/demo/dto/alert/response/AlertInfoResponseDto.java
@@ -1,8 +1,11 @@
 package com.example.demo.dto.alert.response;
 
 import com.example.demo.constant.AlertType;
+import com.example.demo.global.util.LocalDateTimeFormatSerializer;
 import com.example.demo.model.alert.Alert;
 import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.util.ObjectUtils;
@@ -19,7 +22,11 @@ public class AlertInfoResponseDto {
     private Long positionId;
     private String content;
     private AlertType type;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime createDate;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime updateDate;
 
     public static AlertInfoResponseDto of(Alert alert) {

--- a/src/main/java/com/example/demo/dto/board/Response/BoardCreateResponseDto.java
+++ b/src/main/java/com/example/demo/dto/board/Response/BoardCreateResponseDto.java
@@ -1,7 +1,10 @@
 package com.example.demo.dto.board.response;
 
+import com.example.demo.global.util.LocalDateTimeFormatSerializer;
 import com.example.demo.model.board.Board;
 import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,7 +17,11 @@ public class BoardCreateResponseDto {
     private boolean boardCompleteStatus;
     private long boardUserId;
     private String boardContact;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime createDate;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime updateDate;
 
     public static BoardCreateResponseDto of(Board board) {

--- a/src/main/java/com/example/demo/dto/board/Response/BoardDetailResponseDto.java
+++ b/src/main/java/com/example/demo/dto/board/Response/BoardDetailResponseDto.java
@@ -2,9 +2,12 @@ package com.example.demo.dto.board.response;
 
 import com.example.demo.dto.boardposition.BoardPositionDetailResponseDto;
 import com.example.demo.dto.user.response.UserBoardDetailResponseDto;
+import com.example.demo.global.util.LocalDateTimeFormatSerializer;
 import com.example.demo.model.board.Board;
 import java.time.LocalDateTime;
 import java.util.List;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -18,7 +21,11 @@ public class BoardDetailResponseDto {
     private boolean compeleteStatus;
     private UserBoardDetailResponseDto user;
     private String contact;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime createDate;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime updateDate;
     private List<BoardPositionDetailResponseDto> boardPositions;
 

--- a/src/main/java/com/example/demo/dto/board/Response/BoardSearchResponseDto.java
+++ b/src/main/java/com/example/demo/dto/board/Response/BoardSearchResponseDto.java
@@ -2,7 +2,9 @@ package com.example.demo.dto.board.response;
 
 import com.example.demo.dto.project.response.ProjectSearchResponseDto;
 import com.example.demo.dto.user.response.UserSearchResponseDto;
+import com.example.demo.global.util.LocalDateTimeFormatSerializer;
 import com.example.demo.model.board.Board;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -21,7 +23,11 @@ public class BoardSearchResponseDto {
     private boolean boardCompleteStatus;
     private UserSearchResponseDto user;
     private String boardContact;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime createDate;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime updateDate;
 
     @QueryProjection

--- a/src/main/java/com/example/demo/dto/board/Response/BoardUpdateResponseDto.java
+++ b/src/main/java/com/example/demo/dto/board/Response/BoardUpdateResponseDto.java
@@ -1,7 +1,10 @@
 package com.example.demo.dto.board.response;
 
+import com.example.demo.global.util.LocalDateTimeFormatSerializer;
 import com.example.demo.model.board.Board;
 import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -15,7 +18,11 @@ public class BoardUpdateResponseDto {
     private boolean boardCompleteStatus;
     private long boardUserId;
     private String boardContact;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime createDate;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime updateDate;
 
     public static BoardUpdateResponseDto of(Board board) {

--- a/src/main/java/com/example/demo/dto/milestone/response/MilestoneCreateResponseDto.java
+++ b/src/main/java/com/example/demo/dto/milestone/response/MilestoneCreateResponseDto.java
@@ -1,9 +1,12 @@
 package com.example.demo.dto.milestone;
 
+import com.example.demo.global.util.LocalDateTimeFormatSerializer;
 import com.example.demo.model.milestone.Milestone;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -17,7 +20,11 @@ public class MilestoneCreateResponseDto {
     private LocalDate endDate;
     private boolean expireStatus;
     private boolean completeStatus;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime createDate;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime updateDate;
 
     public static MilestoneCreateResponseDto of(Milestone milestone) {

--- a/src/main/java/com/example/demo/dto/milestone/response/MilestoneReadResponseDto.java
+++ b/src/main/java/com/example/demo/dto/milestone/response/MilestoneReadResponseDto.java
@@ -1,9 +1,12 @@
 package com.example.demo.dto.milestone.response;
 
+import com.example.demo.global.util.LocalDateTimeFormatSerializer;
 import com.example.demo.model.milestone.Milestone;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -17,7 +20,11 @@ public class MilestoneReadResponseDto {
     private LocalDate endDate;
     private boolean expireStatus;
     private boolean completeStatus;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime createDate;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime updateDate;
 
     public static MilestoneReadResponseDto of(Milestone milestone) {

--- a/src/main/java/com/example/demo/dto/project/response/ProjectCreateResponseDto.java
+++ b/src/main/java/com/example/demo/dto/project/response/ProjectCreateResponseDto.java
@@ -1,10 +1,13 @@
 package com.example.demo.dto.project.response;
 
 import com.example.demo.constant.ProjectStatus;
+import com.example.demo.global.util.LocalDateTimeFormatSerializer;
 import com.example.demo.model.project.Project;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -19,7 +22,11 @@ public class ProjectCreateResponseDto {
     private int crewNumber;
     private LocalDate startDate;
     private LocalDate endDate;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime createDate;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime updateDate;
 
     public static ProjectCreateResponseDto of(Project project) {

--- a/src/main/java/com/example/demo/dto/project/response/ProjectDetailResponseDto.java
+++ b/src/main/java/com/example/demo/dto/project/response/ProjectDetailResponseDto.java
@@ -4,11 +4,14 @@ import com.example.demo.constant.ProjectStatus;
 import com.example.demo.dto.technology_stack.response.TechnologyStackInfoResponseDto;
 import com.example.demo.dto.trust_grade.response.TrustGradeResponseDto;
 import com.example.demo.dto.user.response.UserProjectResponseDto;
+import com.example.demo.global.util.LocalDateTimeFormatSerializer;
 import com.example.demo.model.project.Project;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -24,7 +27,11 @@ public class ProjectDetailResponseDto {
     private int crewNumber;
     private LocalDate startDate;
     private LocalDate endDate;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime createDate;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime updateDate;
     private List<TechnologyStackInfoResponseDto> technologyStacks;
 

--- a/src/main/java/com/example/demo/dto/project/response/ProjectMeResponseDto.java
+++ b/src/main/java/com/example/demo/dto/project/response/ProjectMeResponseDto.java
@@ -3,11 +3,14 @@ package com.example.demo.dto.project.response;
 import com.example.demo.constant.ProjectStatus;
 import com.example.demo.dto.projectmember.response.MyProjectMemberResponseDto;
 import com.example.demo.dto.trust_grade.response.TrustGradeResponseDto;
+import com.example.demo.global.util.LocalDateTimeFormatSerializer;
 import com.example.demo.model.project.Project;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -23,7 +26,11 @@ public class ProjectMeResponseDto {
     private int crewNumber;
     private LocalDate startDate;
     private LocalDate endDate;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime createDate;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime updateDate;
 
     public static ProjectMeResponseDto of(

--- a/src/main/java/com/example/demo/dto/project/response/ProjectSpecificDetailResponseDto.java
+++ b/src/main/java/com/example/demo/dto/project/response/ProjectSpecificDetailResponseDto.java
@@ -2,10 +2,13 @@ package com.example.demo.dto.project.response;
 
 import com.example.demo.constant.ProjectStatus;
 import com.example.demo.dto.trust_grade.response.TrustGradeResponseDto;
+import com.example.demo.global.util.LocalDateTimeFormatSerializer;
 import com.example.demo.model.project.Project;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -20,7 +23,11 @@ public class ProjectSpecificDetailResponseDto {
     private int crewNumber;
     private LocalDate startDate;
     private LocalDate endDate;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime createDate;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime updateDate;
 
     public static ProjectSpecificDetailResponseDto of(

--- a/src/main/java/com/example/demo/dto/project/response/ProjectUpdateResponseDto.java
+++ b/src/main/java/com/example/demo/dto/project/response/ProjectUpdateResponseDto.java
@@ -1,10 +1,13 @@
 package com.example.demo.dto.project.response;
 
 import com.example.demo.constant.ProjectStatus;
+import com.example.demo.global.util.LocalDateTimeFormatSerializer;
 import com.example.demo.model.project.Project;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -20,7 +23,11 @@ public class ProjectUpdateResponseDto {
     private int crewNumber;
     private LocalDate startDate;
     private LocalDate endDate;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime createDate;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime updateDate;
 
     public static ProjectUpdateResponseDto of(Project project) {

--- a/src/main/java/com/example/demo/dto/projectmember/response/ProjectMemberDetailResponseDto.java
+++ b/src/main/java/com/example/demo/dto/projectmember/response/ProjectMemberDetailResponseDto.java
@@ -3,8 +3,11 @@ package com.example.demo.dto.projectmember.response;
 import com.example.demo.constant.ProjectMemberStatus;
 import com.example.demo.dto.position.response.PositionResponseDto;
 import com.example.demo.dto.user.response.UserProjectDetailResponseDto;
+import com.example.demo.global.util.LocalDateTimeFormatSerializer;
 import com.example.demo.model.project.ProjectMember;
 import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -16,7 +19,11 @@ public class ProjectMemberDetailResponseDto {
     private ProjectMemberAuthResponseDto projectMemberAuth;
     private PositionResponseDto position;
     private ProjectMemberStatus status;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime createDate;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime updateDate;
 
     public static ProjectMemberDetailResponseDto of(

--- a/src/main/java/com/example/demo/dto/projectmember/response/ProjectMemberReadProjectCrewsResponseDto.java
+++ b/src/main/java/com/example/demo/dto/projectmember/response/ProjectMemberReadProjectCrewsResponseDto.java
@@ -2,8 +2,11 @@ package com.example.demo.dto.projectmember.response;
 
 import com.example.demo.dto.position.response.PositionResponseDto;
 import com.example.demo.dto.user.response.UserReadProjectCrewResponseDto;
+import com.example.demo.global.util.LocalDateTimeFormatSerializer;
 import com.example.demo.model.project.ProjectMember;
 import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,6 +17,8 @@ public class ProjectMemberReadProjectCrewsResponseDto {
     private UserReadProjectCrewResponseDto user;
     private ProjectMemberAuthResponseDto projectMemberAuth;
     private PositionResponseDto position;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime lastWorkDate;
 
     public static ProjectMemberReadProjectCrewsResponseDto of(

--- a/src/main/java/com/example/demo/dto/trust_score/ProjectUserHistoryDto.java
+++ b/src/main/java/com/example/demo/dto/trust_score/ProjectUserHistoryDto.java
@@ -1,6 +1,9 @@
 package com.example.demo.dto.trust_score;
 
 import java.time.LocalDateTime;
+
+import com.example.demo.global.util.LocalDateTimeFormatSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,6 +14,8 @@ public class ProjectUserHistoryDto {
     Boolean completeStatus;
     String content;
     Integer trustScore;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     LocalDateTime createDate;
 
     public ProjectUserHistoryDto(

--- a/src/main/java/com/example/demo/dto/user/response/UserCrewDetailResponseDto.java
+++ b/src/main/java/com/example/demo/dto/user/response/UserCrewDetailResponseDto.java
@@ -4,9 +4,12 @@ import com.example.demo.constant.Role;
 import com.example.demo.dto.position.response.PositionResponseDto;
 import com.example.demo.dto.technology_stack.response.TechnologyStackInfoResponseDto;
 import com.example.demo.dto.trust_grade.response.TrustGradeResponseDto;
+import com.example.demo.global.util.LocalDateTimeFormatSerializer;
 import com.example.demo.model.user.User;
 import java.time.LocalDateTime;
 import java.util.List;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -23,7 +26,11 @@ public class UserCrewDetailResponseDto {
     private Role role;
     private String intro;
     private List<TechnologyStackInfoResponseDto> technologyStacks;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime createDate;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime updateDate;
 
     public static UserCrewDetailResponseDto of(

--- a/src/main/java/com/example/demo/dto/user/response/UserMyInfoResponseDto.java
+++ b/src/main/java/com/example/demo/dto/user/response/UserMyInfoResponseDto.java
@@ -6,6 +6,9 @@ import com.example.demo.dto.trust_grade.response.TrustGradeInfoResponseDto;
 
 import java.time.LocalDateTime;
 import java.util.List;
+
+import com.example.demo.global.util.LocalDateTimeFormatSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -33,8 +36,10 @@ public class UserMyInfoResponseDto {
 
     private long projectHistoryTotalCount;
 
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime createDate;
 
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime updateDate;
 
     public static UserMyInfoResponseDto of(

--- a/src/main/java/com/example/demo/dto/work/response/WorkProjectDetailResponseDto.java
+++ b/src/main/java/com/example/demo/dto/work/response/WorkProjectDetailResponseDto.java
@@ -1,11 +1,14 @@
 package com.example.demo.dto.work.response;
 
 import com.example.demo.dto.user.response.UserProjectDetailResponseDto;
+import com.example.demo.global.util.LocalDateTimeFormatSerializer;
 import com.example.demo.model.project.ProjectMember;
 import com.example.demo.model.work.Work;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -20,7 +23,11 @@ public class WorkProjectDetailResponseDto {
     private Boolean completeStatus;
     private LocalDate startDate;
     private LocalDate endDate;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime createDate;
+
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime updateDate;
 
     public static WorkProjectDetailResponseDto of(


### PR DESCRIPTION
### 작업내용
- 각 도메인별 응답 DTO에서 LocalDateTime 타입의 날짜 데이터 필드를 "yyyy-MM-dd" 형태로 응답하기 위한 JsonSerialize 어노테이션 직렬화 코드 추가


### 연관이슈
#240 