### PR TITLE
[feature/fix-user-get-my-projecthistorys] 내 프로젝트 이력 목록 조회 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/controller/user/UserController.java
+++ b/src/main/java/com/example/demo/controller/user/UserController.java
@@ -13,6 +13,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Optional;
+
 @RestController
 @RequestMapping("/api/user")
 @RequiredArgsConstructor
@@ -63,7 +65,7 @@ public class UserController {
 
     // 내 프로젝트 이력 목록 조회
     @GetMapping("/me/project-history")
-    public ResponseEntity<ResponseDto<?>> myProjectHistoryList(@AuthenticationPrincipal PrincipalDetails user, @RequestParam int pageNumber) {
-        return ResponseEntity.status(HttpStatus.OK).body(userFacade.getMyProjectHistoryList(user, pageNumber));
+    public ResponseEntity<ResponseDto<?>> myProjectHistoryList(@AuthenticationPrincipal PrincipalDetails user, @RequestParam Optional<Integer> pageNumber) {
+        return ResponseEntity.status(HttpStatus.OK).body(userFacade.getMyProjectHistoryList(user, pageNumber.orElse(0)));
     }
 }

--- a/src/main/java/com/example/demo/dto/user/response/UserProjectHistoryInfoResponseDto.java
+++ b/src/main/java/com/example/demo/dto/user/response/UserProjectHistoryInfoResponseDto.java
@@ -1,8 +1,12 @@
 package com.example.demo.dto.user.response;
 
 import com.example.demo.constant.UserProjectHistoryStatus;
+import com.example.demo.global.util.LocalDateTimeFormatSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @AllArgsConstructor
 @Getter
@@ -14,5 +18,6 @@ public class UserProjectHistoryInfoResponseDto {
 
     private String projectName;
 
-    private String updateDate;
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
+    private LocalDateTime updateDate;
 }

--- a/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepositoryImpl.java
@@ -42,9 +42,7 @@ public class UserProjectHistoryRepositoryImpl implements UserProjectHistoryRepos
                                         userProjectHistory.id,
                                         userProjectHistory.status,
                                         userProjectHistory.project.name,
-                                        Expressions.stringTemplate(
-                                                "DATE_FORMAT(userProjectHistory.updateDate, '%Y %b %d %H:%i:%s')",
-                                                userProjectHistory.updateDate)))
+                                        userProjectHistory.updateDate))
                         .from(userProjectHistory)
                         .leftJoin(userProjectHistory.project, project)
                         .leftJoin(userProjectHistory.user, user)

--- a/src/main/java/com/example/demo/service/user/UserFacade.java
+++ b/src/main/java/com/example/demo/service/user/UserFacade.java
@@ -15,6 +15,7 @@ import com.example.demo.dto.user.response.UserMyInfoResponseDto;
 import com.example.demo.dto.user.response.UserProjectHistoryInfoResponseDto;
 import com.example.demo.dto.user.response.UserSimpleInfoResponseDto;
 import com.example.demo.dto.user.response.UserUpdateResponseDto;
+import com.example.demo.global.exception.customexception.PageNationCustomException;
 import com.example.demo.model.position.Position;
 import com.example.demo.model.technology_stack.TechnologyStack;
 import com.example.demo.model.trust_grade.TrustGrade;
@@ -274,6 +275,11 @@ public class UserFacade {
      */
     @Transactional(readOnly = true)
     public ResponseDto<?> getMyProjectHistoryList(PrincipalDetails user, int pageNumber) {
+        // 페이지 번호가 0번보다 작은 경우
+        if(pageNumber < 0) {
+            throw PageNationCustomException.INVALID_PAGE_NUMBER;
+        }
+
         List<UserProjectHistoryInfoResponseDto> projectHistoryList = userProjectHistoryService.getUserProjectHistoryList(user.getId(), pageNumber);
 
         return ResponseDto.success("내 프로젝트 이력 목록 조회가 완료되었습니다.", projectHistoryList);

--- a/src/main/java/com/example/demo/service/user/UserProjectHistoryServiceImpl.java
+++ b/src/main/java/com/example/demo/service/user/UserProjectHistoryServiceImpl.java
@@ -43,7 +43,7 @@ public class UserProjectHistoryServiceImpl implements UserProjectHistoryService 
     @Override
     public List<UserProjectHistoryInfoResponseDto> getUserProjectHistoryList(
             Long userId, int pageNumber) {
-        PageRequest pageRequest = PageRequest.of(pageNumber - 1, 5);
+        PageRequest pageRequest = PageRequest.of(pageNumber, 5);
         return userProjectHistoryRepository.findAllByUserIdOrderByUpdateDateDesc(
                 userId, pageRequest);
     }


### PR DESCRIPTION
### 작업내용
- 기존 int 타입의 pageNumber 데이터를 파라미터로 전달 받아 처리하던 로직에서 null 값에 대비해 Optional<Integer> 타입의 pageNumber 데이터를 전달 받도록 수정해 null인 경우 0번 페이지의 결과 값을 응답받도록 수정
- 요청할 수 있는 최소 페이지 번호를 1번에서 0번으로 변경하여 기존 요청한 페이지 번호 -1 한 값으로 페이징 처리를 수행하던 로직에서 요청한 페이지 번호만으로 페이징 처리를 수행하도록 수정
- 공통 형식의 날짜 데이터를 응답하기 위해 회원 프로젝트 이력 정보 DTO의 updateDate 필드의 타입을 변경하고 직렬화되도록 수정
- 기존 회원 프로젝트 이력을 조회하는 쿼리에서 MySQL의 DATE_FORMAT() 함수로 update_date 필드를 설정한 패턴의 String 타입으로 포맷해 응답 데이터를 셋팅하는 로직에서 LocalDateTime 타입의 update_date 정보를 그대로 가져와 응답 DTO단에서 직렬화를 통해 공통된 형식의 날짜 데이터를 응답하도록 수정