### PR TITLE
[feature/fix-board-search] 게시글 검색 조회 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/controller/board/BoardController.java
+++ b/src/main/java/com/example/demo/controller/board/BoardController.java
@@ -11,6 +11,8 @@ import com.example.demo.dto.common.ResponseDto;
 import com.example.demo.security.custom.PrincipalDetails;
 import com.example.demo.service.board.BoardFacade;
 import com.example.demo.service.board.BoardService;
+
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -29,11 +31,14 @@ public class BoardController {
     private final BoardService boardService;
     private final BoardFacade boardFacade;
 
-    @PostMapping("/search/public")
+    @GetMapping("/search/public")
     public ResponseEntity<ResponseDto<?>> search(
-            @RequestBody BoardSearchRequestDto dto, @RequestParam("page") Optional<Integer> page) {
+            @RequestParam(value = "positionId", required = false) Long positionId,
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(value = "technologyIds", required = false) List<Long> technologyIds,
+            @RequestParam("page") Optional<Integer> page) {
         Pageable pageable = PageRequest.of(page.orElse(0), 5);
-        Page<BoardSearchResponseDto> result = boardService.search(dto, pageable);
+        Page<BoardSearchResponseDto> result = boardService.search(positionId, keyword, technologyIds, pageable);
         return new ResponseEntity<>(ResponseDto.success("success", result), HttpStatus.OK);
     }
 

--- a/src/main/java/com/example/demo/dto/board/Response/BoardSearchResponseDto.java
+++ b/src/main/java/com/example/demo/dto/board/Response/BoardSearchResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.demo.dto.board.response;
 
+import com.example.demo.dto.boardposition.BoardPositionDetailResponseDto;
 import com.example.demo.dto.project.response.ProjectSearchResponseDto;
 import com.example.demo.dto.user.response.UserSearchResponseDto;
 import com.example.demo.global.util.LocalDateTimeFormatSerializer;
@@ -7,6 +8,8 @@ import com.example.demo.model.board.Board;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDateTime;
+import java.util.List;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -16,6 +19,7 @@ public class BoardSearchResponseDto {
     private Long boardId;
     private String boardTitle;
     private String boardContent;
+    private List<BoardPositionDetailResponseDto> boardPositions;
     private ProjectSearchResponseDto project;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
@@ -35,6 +39,7 @@ public class BoardSearchResponseDto {
             Long boardId,
             String boardTitle,
             String boardContent,
+            List<BoardPositionDetailResponseDto> boardPositions,
             ProjectSearchResponseDto project,
             LocalDateTime startDate,
             LocalDateTime endDate,
@@ -47,6 +52,7 @@ public class BoardSearchResponseDto {
         this.boardId = boardId;
         this.boardTitle = boardTitle;
         this.boardContent = boardContent;
+        this.boardPositions = boardPositions;
         this.project = project;
         this.startDate = startDate;
         this.endDate = endDate;
@@ -60,12 +66,14 @@ public class BoardSearchResponseDto {
 
     public static BoardSearchResponseDto of(
             Board board,
+            List<BoardPositionDetailResponseDto> boardPositions,
             ProjectSearchResponseDto boardProjectSearchResponseDto,
             UserSearchResponseDto userSearchResponseDto) {
         return BoardSearchResponseDto.builder()
                 .boardId(board.getId())
                 .boardTitle(board.getTitle())
                 .boardContent(board.getContent())
+                .boardPositions(boardPositions)
                 .project(boardProjectSearchResponseDto)
                 .boardPageView(board.getPageView())
                 .boardCompleteStatus(board.isCompleteStatus())

--- a/src/main/java/com/example/demo/repository/board/BoardRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/board/BoardRepositoryCustom.java
@@ -5,8 +5,10 @@ import com.example.demo.dto.board.response.BoardSearchResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface BoardRepositoryCustom {
 
     Page<BoardSearchResponseDto> getBoardSearchPage(
-            BoardSearchRequestDto boardSearchRequestDto, Pageable pageable);
+            Long positionId, String keyword, List<Long> technologyIds, Pageable pageable);
 }

--- a/src/main/java/com/example/demo/service/board/BoardService.java
+++ b/src/main/java/com/example/demo/service/board/BoardService.java
@@ -8,11 +8,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Transactional
 public interface BoardService {
 
     @Transactional(readOnly = true)
-    public Page<BoardSearchResponseDto> search(BoardSearchRequestDto dto, Pageable pageable);
+    public Page<BoardSearchResponseDto> search(Long positionId, String keyword, List<Long> technologyIds, Pageable pageable);
 
     public Board findById(Long boardId);
 

--- a/src/main/java/com/example/demo/service/board/BoardServiceImpl.java
+++ b/src/main/java/com/example/demo/service/board/BoardServiceImpl.java
@@ -33,12 +33,12 @@ public class BoardServiceImpl implements BoardService {
     /**
      * 게시글 목록 검색
      *
-     * @param dto
+     * @param
      * @return List<BoardSearchResponseDto>
      */
     @Transactional(readOnly = true)
-    public Page<BoardSearchResponseDto> search(BoardSearchRequestDto dto, Pageable pageable) {
-        return boardRepository.getBoardSearchPage(dto, pageable);
+    public Page<BoardSearchResponseDto> search(Long positionId, String keyword, List<Long> technologyIds, Pageable pageable) {
+        return boardRepository.getBoardSearchPage(positionId, keyword, technologyIds, pageable);
     }
 
     public Board findById(Long boardId) {


### PR DESCRIPTION
### 작업내용
- 기존 Post Mapping의 게시글 검색 조회 요청을 Get Mapping으로 변경하고 positionId, keyword, technologyIds 데이터를 쿼리 파라미터로 받도록 수정하고 BoardService의 게시글 검색 로직의 파라미터 정보 변경
- 게시글 검색 조회 시 해당 게시글의 직무 목록 정보도 함께 응답하기 위해 BoardSearchResponseDto에 게시글 직무 목록 필드 추가
- 게시글 검색 조회 쿼리에서 or 연산자로 관련 데이터를 조회하던 로직에서 and 연산자로 관련 데이터를 조회하도록 변경 (검색 조건과 일치하는 데이터를 조회하기 위해)
- 게시글 검색 조회 쿼리에 게시글 직무 관련 응답 데이터를 생성하는 로직 추가