### PR TITLE
[feature/work-field-modify] 업무 엔티티 관련 필드 수정 및 리팩토링

### DIFF
--- a/src/main/java/com/example/demo/dto/trust_score/ProjectUserHistoryDto.java
+++ b/src/main/java/com/example/demo/dto/trust_score/ProjectUserHistoryDto.java
@@ -2,6 +2,7 @@ package com.example.demo.dto.trust_score;
 
 import java.time.LocalDateTime;
 
+import com.example.demo.constant.ProgressStatus;
 import com.example.demo.global.util.LocalDateTimeFormatSerializer;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Getter;
@@ -11,7 +12,7 @@ import lombok.Setter;
 @Setter
 public class ProjectUserHistoryDto {
     Long id;
-    Boolean completeStatus;
+    ProgressStatus progressStatus;
     String content;
     Integer trustScore;
 
@@ -21,12 +22,12 @@ public class ProjectUserHistoryDto {
     public ProjectUserHistoryDto(
             Long workId,
             Integer score,
-            Boolean completeStatus,
+            ProgressStatus progressStatus,
             String content,
             LocalDateTime createDate) {
         this.id = workId;
         this.trustScore = score;
-        this.completeStatus = completeStatus;
+        this.progressStatus = progressStatus;
         this.content = content;
         this.createDate = createDate;
     }

--- a/src/main/java/com/example/demo/dto/work/request/WorkCreateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/work/request/WorkCreateRequestDto.java
@@ -1,5 +1,6 @@
 package com.example.demo.dto.work.request;
 
+import com.example.demo.constant.ProgressStatus;
 import com.example.demo.model.milestone.Milestone;
 import com.example.demo.model.project.Project;
 import com.example.demo.model.project.ProjectMember;
@@ -27,8 +28,7 @@ public class WorkCreateRequestDto {
                 .assignedUserId(user)
                 .lastModifiedMember(projectMember)
                 .content(this.getContent())
-                .expireStatus(false)
-                .completeStatus(false)
+                .progressStatus(ProgressStatus.BEFORE_START)
                 .startDate(this.getStartDate())
                 .endDate(this.getEndDate())
                 .build();

--- a/src/main/java/com/example/demo/dto/work/request/WorkReadResponseDto.java
+++ b/src/main/java/com/example/demo/dto/work/request/WorkReadResponseDto.java
@@ -18,8 +18,7 @@ public class WorkReadResponseDto {
     private String content;
     private LocalDate startDate;
     private LocalDate endDate;
-    private boolean expireStatus;
-    private boolean completeStauts;
+    private String progressStatus;
 
     public static WorkReadResponseDto of(Work work) {
         return WorkReadResponseDto.builder()
@@ -31,8 +30,7 @@ public class WorkReadResponseDto {
                 .content(work.getContent())
                 .startDate(work.getStartDate())
                 .endDate(work.getEndDate())
-                .expireStatus(work.isExpireStatus())
-                .completeStauts(work.isCompleteStatus())
+                .progressStatus(work.getProgressStatus().getDescription())
                 .build();
     }
 }

--- a/src/main/java/com/example/demo/dto/work/response/WorkProjectDetailResponseDto.java
+++ b/src/main/java/com/example/demo/dto/work/response/WorkProjectDetailResponseDto.java
@@ -19,8 +19,7 @@ public class WorkProjectDetailResponseDto {
     private UserProjectDetailResponseDto assginedUser;
     private ProjectMember lastModifiedMember;
     private String workContent;
-    private Boolean expireStatus;
-    private Boolean completeStatus;
+    private String progressStatus;
     private LocalDate startDate;
     private LocalDate endDate;
 
@@ -37,8 +36,7 @@ public class WorkProjectDetailResponseDto {
                 .assginedUser(userProjectDetailResponseDto)
                 .lastModifiedMember(work.getLastModifiedMember())
                 .workContent(work.getContent())
-                .expireStatus(work.isExpireStatus())
-                .completeStatus(work.isCompleteStatus())
+                .progressStatus(work.getProgressStatus().getDescription())
                 .startDate(work.getStartDate())
                 .endDate(work.getEndDate())
                 .createDate(work.getCreateDate())

--- a/src/main/java/com/example/demo/global/validation/validator/AddPointDtoValidator.java
+++ b/src/main/java/com/example/demo/global/validation/validator/AddPointDtoValidator.java
@@ -2,6 +2,7 @@ package com.example.demo.global.validation.validator;
 
 import static com.example.demo.constant.TrustScoreTypeIdentifier.*;
 
+import com.example.demo.constant.ProgressStatus;
 import com.example.demo.dto.trust_score.AddPointDto;
 import com.example.demo.global.exception.customexception.ProjectCustomException;
 import com.example.demo.global.exception.customexception.UserCustomException;
@@ -84,7 +85,7 @@ public class AddPointDtoValidator implements ConstraintValidator<ValidAddPointDt
                         .findById(workId)
                         .orElseThrow(() -> WorkCustomException.NOT_FOUND_WORK);
 
-        if (work.isCompleteStatus()) {
+        if (work.getProgressStatus().equals(ProgressStatus.COMPLETION)) {
             log.info("데이터 무결성 위배. 업무 완료여부 불일치. workId : {}", workId);
             return false;
         }
@@ -257,7 +258,7 @@ public class AddPointDtoValidator implements ConstraintValidator<ValidAddPointDt
                         .findById(workId)
                         .orElseThrow(() -> WorkCustomException.NOT_FOUND_WORK);
 
-        if (!work.isCompleteStatus()) {
+        if (!work.getProgressStatus().equals(ProgressStatus.COMPLETION)) {
             log.info("데이터 무결성 위배. 업무 미완성. workId : {}", workId);
             return false;
         }

--- a/src/main/java/com/example/demo/model/work/Work.java
+++ b/src/main/java/com/example/demo/model/work/Work.java
@@ -1,5 +1,6 @@
 package com.example.demo.model.work;
 
+import com.example.demo.constant.ProgressStatus;
 import com.example.demo.dto.work.request.WorkUpdateCompleteStatusRequestDto;
 import com.example.demo.dto.work.request.WorkUpdateContentRequestDto;
 import com.example.demo.dto.work.request.WorkUpdateRequestDto;
@@ -44,11 +45,9 @@ public class Work extends BaseTimeEntity {
     @Column(name = "work_content")
     private String content;
 
-    @Column(name = "expire_statue")
-    private boolean expireStatus;
-
-    @Column(name = "complete_status")
-    private boolean completeStatus;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "progressStatus")
+    private ProgressStatus progressStatus;
 
     @Column(name = "start_date")
     private LocalDate startDate;
@@ -69,8 +68,7 @@ public class Work extends BaseTimeEntity {
             Milestone milestone,
             User assignedUserId,
             String content,
-            boolean expireStatus,
-            boolean completeStatus,
+            ProgressStatus progressStatus,
             LocalDate startDate,
             LocalDate endDate,
             ProjectMember lastModifiedMember) {
@@ -78,8 +76,7 @@ public class Work extends BaseTimeEntity {
         this.milestone = milestone;
         this.assignedUserId = assignedUserId;
         this.content = content;
-        this.expireStatus = expireStatus;
-        this.completeStatus = completeStatus;
+        this.progressStatus = progressStatus;
         this.startDate = startDate;
         this.endDate = endDate;
         this.lastModifiedMember = lastModifiedMember;
@@ -99,7 +96,7 @@ public class Work extends BaseTimeEntity {
 
     public void updateCompleteStatus(
             WorkUpdateCompleteStatusRequestDto dto, ProjectMember projectMember) {
-        this.completeStatus = dto.getCompleteStatus();
+        //this.completeStatus = dto.getCompleteStatus();
         this.lastModifiedMember = projectMember;
     }
 

--- a/src/main/java/com/example/demo/repository/trust_score/TrustScoreHistoryRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/trust_score/TrustScoreHistoryRepositoryImpl.java
@@ -32,7 +32,7 @@ public class TrustScoreHistoryRepositoryImpl implements TrustScoreHistoryReposit
                                 ProjectUserHistoryDto.class,
                                 trustScoreHistory.workId,
                                 trustScoreHistory.score,
-                                work.completeStatus,
+                                work.progressStatus,
                                 work.content,
                                 trustScoreHistory.createDate))
                 .from(trustScoreHistory)

--- a/src/main/java/com/example/demo/repository/work/WorkRepository.java
+++ b/src/main/java/com/example/demo/repository/work/WorkRepository.java
@@ -1,5 +1,6 @@
 package com.example.demo.repository.work;
 
+import com.example.demo.constant.ProgressStatus;
 import com.example.demo.model.milestone.Milestone;
 import com.example.demo.model.project.Project;
 import com.example.demo.model.user.User;
@@ -13,6 +14,6 @@ public interface WorkRepository extends JpaRepository<Work, Long> {
 
     Optional<List<Work>> findWorksByProjectAndMilestone(Project project, Milestone milestone);
 
-    Optional<Work> findFirstByProjectAndAssignedUserIdAndCompleteStatusOrderByIdDesc(
-            Project project, User user, Boolean completeStatus);
+    Optional<Work> findFirstByProjectAndAssignedUserIdAndProgressStatusOrderByIdDesc(
+            Project project, User user, ProgressStatus progressStatus);
 }

--- a/src/main/java/com/example/demo/service/project/ProjectMemberFacade.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberFacade.java
@@ -109,7 +109,7 @@ public class ProjectMemberFacade {
             PositionResponseDto positionResponseDto =
                     PositionResponseDto.of(projectMember.getPosition());
             Work lastCompleteWork =
-                    workService.findLastCompleteWork(project, projectMember.getUser(), true);
+                    workService.findLastCompleteWork(project, projectMember.getUser());
 
             ProjectMemberReadProjectCrewsResponseDto projectMemberReadProjectCrewsResponseDto =
                     ProjectMemberReadProjectCrewsResponseDto.of(

--- a/src/main/java/com/example/demo/service/work/WorkService.java
+++ b/src/main/java/com/example/demo/service/work/WorkService.java
@@ -17,7 +17,7 @@ public interface WorkService {
 
     public List<Work> findWorksByProject(Project project);
 
-    public Work findLastCompleteWork(Project project, User user, Boolean completeStatus);
+    public Work findLastCompleteWork(Project project, User user);
 
     public List<Work> findWorksByProjectAndMilestone(Project project, Milestone milestone);
 

--- a/src/main/java/com/example/demo/service/work/WorkServiceImpl.java
+++ b/src/main/java/com/example/demo/service/work/WorkServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.demo.service.work;
 
+import com.example.demo.constant.ProgressStatus;
 import com.example.demo.dto.work.request.WorkReadResponseDto;
 import com.example.demo.global.exception.customexception.WorkCustomException;
 import com.example.demo.model.milestone.Milestone;
@@ -31,10 +32,10 @@ public class WorkServiceImpl implements WorkService {
                 .orElseThrow(() -> WorkCustomException.NOT_FOUND_WORK);
     }
 
-    public Work findLastCompleteWork(Project project, User user, Boolean completeStatus) {
+    public Work findLastCompleteWork(Project project, User user) {
         return workRepository
-                .findFirstByProjectAndAssignedUserIdAndCompleteStatusOrderByIdDesc(
-                        project, user, completeStatus)
+                .findFirstByProjectAndAssignedUserIdAndProgressStatusOrderByIdDesc(
+                        project, user, ProgressStatus.COMPLETION)
                 .orElseThrow(() -> WorkCustomException.NOT_FOUND_WORK);
     }
 

--- a/src/test/java/com/example/demo/trust_score/repository/TrustScoreHistoryRepositoryTest.java
+++ b/src/test/java/com/example/demo/trust_score/repository/TrustScoreHistoryRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.example.demo.trust_score.repository;
 
+import com.example.demo.constant.ProgressStatus;
 import com.example.demo.dto.trust_score.ProjectUserHistoryDto;
 import com.example.demo.model.project.Project;
 import com.example.demo.model.trust_score.TrustScoreHistory;
@@ -78,9 +79,9 @@ public class TrustScoreHistoryRepositoryTest {
         Long projectId = saveProject.getId();
 
         // 테스트 업무 생성 및 저장
-        Work testWork1 = Work.builder().content("테스트 업무입니다").completeStatus(true).build();
+        Work testWork1 = Work.builder().content("테스트 업무입니다").progressStatus(ProgressStatus.COMPLETION).build();
 
-        Work testWork2 = Work.builder().content("테스트 업무입니다").completeStatus(false).build();
+        Work testWork2 = Work.builder().content("테스트 업무입니다").progressStatus(ProgressStatus.BEFORE_START).build();
         Work saveWork1 = workRepository.save(testWork1);
         Work saveWork2 = workRepository.save(testWork2);
 

--- a/src/test/java/com/example/demo/trust_score/service/TrustScoreServiceTest.java
+++ b/src/test/java/com/example/demo/trust_score/service/TrustScoreServiceTest.java
@@ -2,6 +2,7 @@ package com.example.demo.trust_score.service;
 
 import static com.example.demo.constant.TrustScoreTypeIdentifier.*;
 
+import com.example.demo.constant.ProgressStatus;
 import com.example.demo.dto.trust_score.AddPointDto;
 import com.example.demo.dto.trust_score.response.TrustScoreUpdateResponseDto;
 import com.example.demo.model.milestone.Milestone;
@@ -42,7 +43,7 @@ public class TrustScoreServiceTest {
         // 업무 생성 및 저장
         Work work =
                 Work.builder()
-                        .completeStatus(true)
+                        .progressStatus(ProgressStatus.COMPLETION)
                         .assignedUserId(user)
                         .project(project)
                         .milestone(milestone)
@@ -91,7 +92,7 @@ public class TrustScoreServiceTest {
         // 업무 생성 및 저장
         Work work =
                 Work.builder()
-                        .completeStatus(true)
+                        .progressStatus(ProgressStatus.COMPLETION)
                         .assignedUserId(user)
                         .project(project)
                         .milestone(milestone)


### PR DESCRIPTION
### 작업내용
- 기존 업무 엔티티의 expired_status, complete_status 두 개의 필드를 삭제하고 progress_status 필드 하나로 공통으로 관리하도록 수정
- 기존 업무 엔티티의 expired_status, complete_status 필드에 접근하고 조작하는 코드를 progress_status 필드로 변경하는 작업 수행
- 업무 생성 시, ProgressStatus.BEFORE_START(시작전) 정보가 저장되도록 수정