### PR TITLE
[feature/fix-work-update] 업무 수정 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/controller/work/WorkController.java
+++ b/src/main/java/com/example/demo/controller/work/WorkController.java
@@ -2,12 +2,14 @@ package com.example.demo.controller.work;
 
 import com.example.demo.dto.common.ResponseDto;
 import com.example.demo.dto.work.request.*;
+import com.example.demo.security.custom.PrincipalDetails;
 import com.example.demo.service.work.WorkFacade;
 import com.example.demo.service.work.WorkService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -49,9 +51,10 @@ public class WorkController {
 
     @PatchMapping("/api/work/{workId}")
     public ResponseEntity<ResponseDto<?>> update(
+            @AuthenticationPrincipal PrincipalDetails user,
             @PathVariable("workId") Long workId,
             @RequestBody WorkUpdateRequestDto workUpdateRequestDto) {
-        workFacade.update(workId, workUpdateRequestDto);
+        workFacade.update(user.getId(), workId, workUpdateRequestDto);
         return new ResponseEntity<>(ResponseDto.success("success"), HttpStatus.OK);
     }
 

--- a/src/main/java/com/example/demo/dto/work/request/WorkUpdateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/work/request/WorkUpdateRequestDto.java
@@ -11,4 +11,5 @@ public class WorkUpdateRequestDto {
     private String content;
     private LocalDate startDate;
     private LocalDate endDate;
+    private String progressStatusCode;
 }

--- a/src/main/java/com/example/demo/model/work/Work.java
+++ b/src/main/java/com/example/demo/model/work/Work.java
@@ -83,10 +83,12 @@ public class Work extends BaseTimeEntity {
         this.completeDate = null;
     }
 
-    public void update(WorkUpdateRequestDto dto) {
+    public void update(WorkUpdateRequestDto dto, ProjectMember projectMember) {
         this.content = dto.getContent();
         this.startDate = dto.getStartDate();
         this.endDate = dto.getEndDate();
+        this.progressStatus = ProgressStatus.getProgressStatusByCode(dto.getProgressStatusCode());
+        this.lastModifiedMember = projectMember;
     }
 
     public void updateContent(WorkUpdateContentRequestDto dto, ProjectMember projectMember) {

--- a/src/main/java/com/example/demo/service/work/WorkFacade.java
+++ b/src/main/java/com/example/demo/service/work/WorkFacade.java
@@ -69,16 +69,16 @@ public class WorkFacade {
     }
 
     /**
-     * 업무 수정 TODO : 마지막 수정자 현재 유저인 구성원으로 변경
+     * 업무 수정
      *
      * @param workId
      */
-    public void update(Long workId, WorkUpdateRequestDto workUpdateRequestDto) {
+    public void update(Long userId, Long workId, WorkUpdateRequestDto workUpdateRequestDto) {
         Work work = workService.findById(workId);
-        User user = userService.findById(1L);
+        User user = userService.findById(userId);
         ProjectMember projectMember =
                 projectMemberService.findProjectMemberByProjectAndUser(work.getProject(), user);
-        work.update(workUpdateRequestDto);
+        work.update(workUpdateRequestDto, projectMember);
     }
 
     /**


### PR DESCRIPTION
### 작업내용
- 기존 업무 엔티티의 progress_status 필드가 추가됨에 따라 업무 수정 요청 시 progress_status 정보도 수정할 수 있도록 WorkUpdateRequestDto에 progressStatusCode 필드 추가
- 기존 업무 엔티티의 수정 로직에 progress_status 정보와 마지막 수정한 프로젝트 구성원의 정보를 함께 수정할 수 있도록 변경
- 업무 수정 요청 시 사용자 정보를 가져올 수 있도록 AuthenticationPrincipal 어노테이션을 추가하여 요청한 사용자의 인증 정보를 파라미터로 받을 수 있도록 수정