### PR TITLE
[feature/add-backend-local-server-origin] CorsConfig 백엔드 로컬 호스트 추가

### DIFF
--- a/src/main/java/com/example/demo/global/config/CorsConfig.java
+++ b/src/main/java/com/example/demo/global/config/CorsConfig.java
@@ -13,6 +13,10 @@ public class CorsConfig {
 
     // 로컬 서버 주소 (프로젝트 완료 후 제거)
     private static final String LOCAL_SERVER_ORIGIN = "http://localhost:3000";
+
+    // 백엔드 로컬 서버 주소 (프로젝트 완료 후 제거)
+    private static final String LOCAL_BACKEND_SERVER_ORIGIN = "http://localhost:8080";
+
     // 배포 서버 주소
     private static final String DEPLOYED_SERVER_ORIGIN = "http://15.164.93.239";
 
@@ -27,6 +31,7 @@ public class CorsConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.addAllowedOrigin(LOCAL_SERVER_ORIGIN);
+        configuration.addAllowedOrigin(LOCAL_BACKEND_SERVER_ORIGIN);
         configuration.addAllowedOrigin(DEPLOYED_SERVER_ORIGIN);
         configuration.setAllowedMethods(PERMIT_HTTP_METHOD);
         configuration.addExposedHeader(AUTHORIZATION_HEADER);


### PR DESCRIPTION
### 작업내용
- 백엔드 로컬에서 배포된 서버 테스트를 위해 CorsConfig에 백엔드 로컬 호스트 추가