### PR TITLE
[feature/268-add-techstack-category-connect-entity] 기술스택 카테고리 매핑 엔티티 추가

### DIFF
--- a/src/main/java/com/example/demo/model/technology_stack/TechnologyStack.java
+++ b/src/main/java/com/example/demo/model/technology_stack/TechnologyStack.java
@@ -17,8 +17,4 @@ public class TechnologyStack {
     private Long id;
 
     private String name;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "technology_stack_category_id")
-    private TechnologyStackCategory technologyStackCategory;
 }

--- a/src/main/java/com/example/demo/model/technology_stack/TechnologyStackCategoryMapping.java
+++ b/src/main/java/com/example/demo/model/technology_stack/TechnologyStackCategoryMapping.java
@@ -1,0 +1,27 @@
+package com.example.demo.model.technology_stack;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "technology_stack_category_mapping")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TechnologyStackCategoryMapping {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "technology_stack_category_mapping_id")
+    private Long technologyStackCategoryMappingId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "technology_stack_id")
+    private TechnologyStack technologyStack;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "technology_stack_category_id")
+    private TechnologyStackCategory category;
+}


### PR DESCRIPTION
### 작업내용
- 요구사항 변경으로 하나의 기술스택이 여러개의 기술스택 카테고리를 가질 수 있도록 수정하면서 기술스택 엔티티와 기술스택 카테고리 엔티티를 연결하는 TechnologyStackCategoryMapping 중간 엔티티 생성
- 기존 TechnologyStack 엔티티의 TechnologyStackCategory 필드를 삭제해 참조 관계를 끊고 중간 엔티티에서 관리하도록 수정 



### 연관이슈
#268 