### PR TITLE
[feature/286-fix-work-update] 업무 수정 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/dto/work/request/WorkUpdateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/work/request/WorkUpdateRequestDto.java
@@ -11,4 +11,5 @@ public class WorkUpdateRequestDto {
     private LocalDate startDate;
     private LocalDate endDate;
     private String progressStatusCode;
+    private Long assignedUserId;
 }

--- a/src/main/java/com/example/demo/model/work/Work.java
+++ b/src/main/java/com/example/demo/model/work/Work.java
@@ -82,12 +82,13 @@ public class Work extends BaseTimeEntity {
         this.completeDate = null;
     }
 
-    public void update(WorkUpdateRequestDto dto, ProjectMember projectMember) {
+    public void update(WorkUpdateRequestDto dto, ProjectMember projectMember, User assignedUser) {
         this.content = dto.getContent();
         this.startDate = dto.getStartDate();
         this.endDate = dto.getEndDate();
         this.progressStatus = ProgressStatus.getProgressStatusByCode(dto.getProgressStatusCode());
         this.lastModifiedMember = projectMember;
+        this.assignedUserId = assignedUser;
     }
 
     public void updateContent(WorkUpdateContentRequestDto dto, ProjectMember projectMember) {

--- a/src/main/java/com/example/demo/service/work/WorkFacade.java
+++ b/src/main/java/com/example/demo/service/work/WorkFacade.java
@@ -79,7 +79,11 @@ public class WorkFacade {
         User user = userService.findById(userId);
         ProjectMember projectMember =
                 projectMemberService.findProjectMemberByProjectAndUser(work.getProject(), user);
-        work.update(workUpdateRequestDto, projectMember);
+
+        // 할당된 회원 정보
+        ProjectMember assignedUser = projectMemberService.findById(workUpdateRequestDto.getAssignedUserId());
+
+        work.update(workUpdateRequestDto, projectMember, assignedUser.getUser());
     }
 
     /**


### PR DESCRIPTION
### 작업내용
- 요구사항 변경으로 업무 수정 시 업무에 할당된 회원을 함께 수정하도록 로직 수정
- 업무 수정 요청 DTO WorkUpdateRequestDto에 Long 타입의 assignUserId 필드를 추가해 클라이언트로부터 변경하고자하는 프로젝트의 멤버 ID(PK) 값을 함께 요청 받아 할당된 회원을 함께 수정할 수 있도록 수정



### 연관이슈
close #286