### PR TITLE
[feature/290-fix-get-work-list] 프로젝트 > 마일스톤 > 업무 목록 조회 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/controller/work/WorkController.java
+++ b/src/main/java/com/example/demo/controller/work/WorkController.java
@@ -7,7 +7,11 @@ import com.example.demo.security.custom.PrincipalDetails;
 import com.example.demo.service.work.WorkFacade;
 import com.example.demo.service.work.WorkService;
 import java.util.List;
+import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -39,9 +43,10 @@ public class WorkController {
     @GetMapping("/api/work/project/{projectId}/milestone/{milestoneId}")
     public ResponseEntity<ResponseDto<?>> getAllByMilestone(
             @PathVariable("projectId") Long projectId,
-            @PathVariable("milestoneId") Long milestoneId) {
-        List<WorkReadResponseDto> result = workFacade.getAllByMilestone(projectId, milestoneId);
-        return new ResponseEntity<>(ResponseDto.success("success", result), HttpStatus.OK);
+            @PathVariable("milestoneId") Long milestoneId,
+            @RequestParam("pageIndex") Optional<Integer> pageIndex,
+            @RequestParam("itemCount") Optional<Integer> itemCount) {
+        return new ResponseEntity<>(ResponseDto.success("success", workFacade.getAllByMilestone(projectId, milestoneId, pageIndex.orElse(0), itemCount.orElse(6))), HttpStatus.OK);
     }
 
     @GetMapping("/api/work/{workId}")

--- a/src/main/java/com/example/demo/dto/work/response/WorkPaginationResponseDto.java
+++ b/src/main/java/com/example/demo/dto/work/response/WorkPaginationResponseDto.java
@@ -1,0 +1,21 @@
+package com.example.demo.dto.work.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class WorkPaginationResponseDto {
+
+    private List<WorkReadResponseDto> content;
+    private long totalPages;
+
+    public static WorkPaginationResponseDto of(List<WorkReadResponseDto> content, long totalPages) {
+        return WorkPaginationResponseDto.builder()
+                .content(content)
+                .totalPages(totalPages)
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/dto/work/response/WorkReadResponseDto.java
+++ b/src/main/java/com/example/demo/dto/work/response/WorkReadResponseDto.java
@@ -1,12 +1,16 @@
 package com.example.demo.dto.work.response;
 
+import com.example.demo.constant.ProgressStatus;
 import com.example.demo.model.work.Work;
 import java.time.LocalDate;
+
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@AllArgsConstructor
 public class WorkReadResponseDto {
     private Long workId;
     private Long projectId;
@@ -17,6 +21,19 @@ public class WorkReadResponseDto {
     private LocalDate startDate;
     private LocalDate endDate;
     private String progressStatus;
+
+    public WorkReadResponseDto(Long workId, Long projectId, Long milestoneId, String assignedUserNickname, String lastModifiedMemberNickname,
+                               String content, LocalDate startDate, LocalDate endDate, ProgressStatus progressStatus) {
+        this.workId = workId;
+        this.projectId = projectId;
+        this.milestoneId = milestoneId;
+        this.assignedUserNickname = assignedUserNickname;
+        this.lastModifiedMemberNickname = lastModifiedMemberNickname;
+        this.content = content;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.progressStatus = progressStatus.getDescription();
+    }
 
     public static WorkReadResponseDto of(Work work) {
         return WorkReadResponseDto.builder()

--- a/src/main/java/com/example/demo/global/exception/customexception/PageNationCustomException.java
+++ b/src/main/java/com/example/demo/global/exception/customexception/PageNationCustomException.java
@@ -7,6 +7,9 @@ public class PageNationCustomException extends CustomException {
     public static final PageNationCustomException INVALID_PAGE_NUMBER =
             new PageNationCustomException(PageNationErrorCode.INVALID_PAGE_NUMBER);
 
+    public static final PageNationCustomException INVALID_PAGE_ITEM_COUNT =
+            new PageNationCustomException(PageNationErrorCode.INVALID_PAGE_ITEM_COUNT);
+
     public PageNationCustomException(PageNationErrorCode pageNationErrorCode) {
         super(pageNationErrorCode);
     }

--- a/src/main/java/com/example/demo/global/exception/errorcode/PageNationErrorCode.java
+++ b/src/main/java/com/example/demo/global/exception/errorcode/PageNationErrorCode.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
 public enum PageNationErrorCode implements ErrorCode {
-    INVALID_PAGE_NUMBER(HttpStatus.BAD_REQUEST, "페이지 번호는 최소 0번 이상 이여야 합니다.");
+    INVALID_PAGE_NUMBER(HttpStatus.BAD_REQUEST, "페이지 번호는 최소 0번 이상 이여야 합니다."),
+    INVALID_PAGE_ITEM_COUNT(HttpStatus.BAD_REQUEST, "한 페이지에 요청할 수 있는 데이터의 개수 범위를 확인해주세요.");
 
     private HttpStatus status;
     private String message;

--- a/src/main/java/com/example/demo/repository/work/WorkRepository.java
+++ b/src/main/java/com/example/demo/repository/work/WorkRepository.java
@@ -9,10 +9,8 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface WorkRepository extends JpaRepository<Work, Long> {
+public interface WorkRepository extends JpaRepository<Work, Long>, WorkRepositoryCustom {
     Optional<List<Work>> findWorksByProject(Project project);
-
-    Optional<List<Work>> findWorksByProjectAndMilestone(Project project, Milestone milestone);
 
     Optional<Work> findFirstByProjectAndAssignedUserIdAndProgressStatusOrderByIdDesc(
             Project project, User user, ProgressStatus progressStatus);

--- a/src/main/java/com/example/demo/repository/work/WorkRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/work/WorkRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.example.demo.repository.work;
+
+import com.example.demo.dto.work.response.WorkPaginationResponseDto;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface WorkRepositoryCustom {
+
+    // 프로젝트 > 마일스톤 > 업무 리스트 조회 (시작날짜 기준 오름차순 정렬, 페이징)
+    WorkPaginationResponseDto findWorkByProjectIdAndMilestoneIdOrderByStartDateAsc(Long projectId, Long milestoneId, Pageable pageable);
+}

--- a/src/main/java/com/example/demo/repository/work/WorkRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/work/WorkRepositoryImpl.java
@@ -1,0 +1,89 @@
+package com.example.demo.repository.work;
+
+import com.example.demo.dto.work.response.WorkPaginationResponseDto;
+import com.example.demo.dto.work.response.WorkReadResponseDto;
+import com.example.demo.model.milestone.QMilestone;
+import com.example.demo.model.project.QProject;
+import com.example.demo.model.project.QProjectMember;
+import com.example.demo.model.user.QUser;
+import com.example.demo.model.work.QWork;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class WorkRepositoryImpl implements WorkRepositoryCustom{
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QProject qProject = QProject.project;
+    private final QMilestone qMilestone = QMilestone.milestone;
+
+    private final QWork qWork = QWork.work;
+
+    @Override
+    public WorkPaginationResponseDto findWorkByProjectIdAndMilestoneIdOrderByStartDateAsc(Long projectId, Long milestoneId, Pageable pageable) {
+        QUser qUser = QUser.user;
+        QProjectMember qProjectMember = QProjectMember.projectMember;
+
+        // 업무 목록 조회
+        List<WorkReadResponseDto> content = jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                WorkReadResponseDto.class,
+                                qWork.id,
+                                qProject.id,
+                                qMilestone.id,
+                                qUser.nickname,
+                                qProjectMember.user.nickname,
+                                qWork.content,
+                                qWork.startDate,
+                                qWork.endDate,
+                                qWork.progressStatus
+                        )
+                )
+                .from(qWork)
+                .leftJoin(qWork.project, qProject)
+                .leftJoin(qWork.milestone, qMilestone)
+                .leftJoin(qWork.assignedUserId, qUser)
+                .leftJoin(qWork.lastModifiedMember, qProjectMember)
+                .where(getPredicateForProjectAndMilestone(projectId, milestoneId))
+                .orderBy(qWork.startDate.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 업무 전체 갯수 조회
+        long totalPages = getTotalItemCount(projectId, milestoneId);
+
+        return WorkPaginationResponseDto.of(content, totalPages);
+    }
+
+    private Long getTotalItemCount(Long projectId, Long milestoneId) {
+        // 프로젝트 > 마일스톤 > 업무 전체 갯수 조회
+        return jpaQueryFactory
+                .select(qWork.count())
+                .from(qWork)
+                .where(getPredicateForProjectAndMilestone(projectId, milestoneId))
+                .fetchOne();
+    }
+
+    private BooleanBuilder getPredicateForProjectAndMilestone(Long projectId, Long milestoneId) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if(projectId != null) {
+            builder.and(qProject.id.eq(projectId));
+        }
+
+        if(milestoneId != null) {
+            builder.and(qMilestone.id.eq(milestoneId));
+        }
+
+        return builder;
+    }
+}

--- a/src/main/java/com/example/demo/service/work/WorkFacade.java
+++ b/src/main/java/com/example/demo/service/work/WorkFacade.java
@@ -1,7 +1,9 @@
 package com.example.demo.service.work;
 
 import com.example.demo.dto.work.request.*;
+import com.example.demo.dto.work.response.WorkPaginationResponseDto;
 import com.example.demo.dto.work.response.WorkReadResponseDto;
+import com.example.demo.global.exception.customexception.PageNationCustomException;
 import com.example.demo.model.milestone.Milestone;
 import com.example.demo.model.project.Project;
 import com.example.demo.model.project.ProjectMember;
@@ -14,6 +16,8 @@ import com.example.demo.service.user.UserService;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,19 +58,22 @@ public class WorkFacade {
     }
 
     @Transactional(readOnly = true)
-    public List<WorkReadResponseDto> getAllByMilestone(Long projectId, Long milestoneId) {
+    public WorkPaginationResponseDto getAllByMilestone(Long projectId, Long milestoneId, int pageIndex, int itemCount) {
         Project project = projectService.findById(projectId);
-
         Milestone milestone = milestoneService.findById(milestoneId);
-        List<Work> works = workService.findWorksByProjectAndMilestone(project, milestone);
 
-        List<WorkReadResponseDto> workReadResponseDtos = new ArrayList<>();
-        for (Work work : works) {
-            WorkReadResponseDto workReadResponseDto = WorkReadResponseDto.of(work);
-            workReadResponseDtos.add(workReadResponseDto);
+        if(pageIndex < 0) {
+            throw PageNationCustomException.INVALID_PAGE_NUMBER;
         }
 
-        return workReadResponseDtos;
+        if(itemCount < 1 || itemCount > 6) {
+            throw PageNationCustomException.INVALID_PAGE_ITEM_COUNT;
+        }
+
+        WorkPaginationResponseDto workPaginationResponse = workService
+                .findWorksByProjectAndMilestone(project.getId(), milestone.getId(), PageRequest.of(pageIndex, itemCount));
+
+        return workPaginationResponse;
     }
 
     /**

--- a/src/main/java/com/example/demo/service/work/WorkService.java
+++ b/src/main/java/com/example/demo/service/work/WorkService.java
@@ -1,11 +1,14 @@
 package com.example.demo.service.work;
 
+import com.example.demo.dto.work.response.WorkPaginationResponseDto;
 import com.example.demo.dto.work.response.WorkReadResponseDto;
 import com.example.demo.model.milestone.Milestone;
 import com.example.demo.model.project.Project;
 import com.example.demo.model.user.User;
 import com.example.demo.model.work.Work;
 import java.util.List;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
@@ -19,7 +22,7 @@ public interface WorkService {
 
     public Work findLastCompleteWork(Project project, User user);
 
-    public List<Work> findWorksByProjectAndMilestone(Project project, Milestone milestone);
+    public WorkPaginationResponseDto findWorksByProjectAndMilestone(Long projectId, Long milestoneId, Pageable pageable);
 
     public WorkReadResponseDto getOne(Long workId);
 

--- a/src/main/java/com/example/demo/service/work/WorkServiceImpl.java
+++ b/src/main/java/com/example/demo/service/work/WorkServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.demo.service.work;
 
 import com.example.demo.constant.ProgressStatus;
+import com.example.demo.dto.work.response.WorkPaginationResponseDto;
 import com.example.demo.dto.work.response.WorkReadResponseDto;
 import com.example.demo.global.exception.customexception.WorkCustomException;
 import com.example.demo.model.milestone.Milestone;
@@ -10,6 +11,7 @@ import com.example.demo.model.work.Work;
 import com.example.demo.repository.work.WorkRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -39,10 +41,9 @@ public class WorkServiceImpl implements WorkService {
                 .orElseThrow(() -> WorkCustomException.NOT_FOUND_WORK);
     }
 
-    public List<Work> findWorksByProjectAndMilestone(Project project, Milestone milestone) {
+    public WorkPaginationResponseDto findWorksByProjectAndMilestone(Long projectId, Long milestoneId, Pageable pageable) {
         return workRepository
-                .findWorksByProjectAndMilestone(project, milestone)
-                .orElseThrow(() -> WorkCustomException.NOT_FOUND_WORK);
+                .findWorkByProjectIdAndMilestoneIdOrderByStartDateAsc(projectId, milestoneId, pageable);
     }
 
     public WorkReadResponseDto getOne(Long workId) {


### PR DESCRIPTION
### 작업내용
- 요구사항 변경으로 기존 프로젝트 > 마일스톤 > 업무 목록을 조회하는 로직에 페이징 작업 추가
- WorkRepositoryCustom, WorkRepositoryImpl 커스텀 레파지토리를 생성하고 QueryDsl을 사용해 조건에 맞는 데이터들을 페이징 처리하고 응답하도록 로직 수정 (시작날짜 기준 오름차순 정렬, 최소 0번 pageIndex, 최대 8개의 itemCount)
- 요청 페이지 데이터 개수관련 에러코드 및 커스텀 예외 생성



### 연관이슈
close #290 