### PR TITLE
[feature/304-participating-my-project-list] 회원의 참여중인 프로젝트 목록을 조회하는 로직 구현

### DIFF
--- a/src/main/java/com/example/demo/controller/project/ProjectController.java
+++ b/src/main/java/com/example/demo/controller/project/ProjectController.java
@@ -11,6 +11,7 @@ import com.example.demo.service.project.ProjectMemberService;
 import com.example.demo.service.project.ProjectService;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -26,6 +27,14 @@ public class ProjectController {
     public final ProjectService projectService;
     public final ProjectFacade projectFacade;
     public final ProjectMemberService projectMemberService;
+
+    @GetMapping("/me/participating")
+    public ResponseEntity<ResponseDto<?>> getMyProjectsParticipates(
+            @AuthenticationPrincipal PrincipalDetails user,
+            @RequestParam("pageIndex") Optional<Integer> pageIndex,
+            @RequestParam("itemCount") Optional<Integer> itemCount) {
+        return new ResponseEntity<>(ResponseDto.success("success", projectFacade.getMyProjectsParticipates(user.getId(), pageIndex.orElse(0), itemCount.orElse(6))), HttpStatus.OK);
+    }
 
     @GetMapping("/me")
     public ResponseEntity<ResponseDto<?>> getMyProjects(

--- a/src/main/java/com/example/demo/dto/project/response/ProjectPaginationResponseDto.java
+++ b/src/main/java/com/example/demo/dto/project/response/ProjectPaginationResponseDto.java
@@ -1,0 +1,21 @@
+package com.example.demo.dto.project.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ProjectPaginationResponseDto {
+
+    private List<ProjectMeResponseDto> content;
+    private long totalPages;
+
+    public static ProjectPaginationResponseDto of(List<ProjectMeResponseDto> content, long totalPages) {
+        return ProjectPaginationResponseDto.builder()
+                .content(content)
+                .totalPages(totalPages)
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepositoryCustom.java
@@ -2,6 +2,8 @@ package com.example.demo.repository.user;
 
 import com.example.demo.dto.user.response.UserProjectHistoryInfoResponseDto;
 import java.util.List;
+
+import com.example.demo.model.user.UserProjectHistory;
 import org.springframework.data.domain.Pageable;
 
 public interface UserProjectHistoryRepositoryCustom {
@@ -12,4 +14,10 @@ public interface UserProjectHistoryRepositoryCustom {
     // 회원 프로젝트 이력 목록 조회 (수정날짜 기준 최신순 정렬, 페이징 offset 방법 활용)
     List<UserProjectHistoryInfoResponseDto> findAllByUserIdOrderByUpdateDateDesc(
             Long userId, Pageable pageable);
+
+    // 회원 참여중인 프로젝트 이력 개수 조회
+    Long countParticipatesUserProjectHistoryByUserId(Long userId);
+
+    // 회원 참여중인 프로젝트 이력 조회 (프로젝트 시작날짜 기준 오름차순 정렬, 페이징 offset 방법 활용)
+    List<UserProjectHistory> findAllUserParticipates(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepositoryImpl.java
@@ -4,7 +4,12 @@ import static com.example.demo.model.project.QProject.project;
 import static com.example.demo.model.user.QUser.user;
 import static com.example.demo.model.user.QUserProjectHistory.userProjectHistory;
 
+import com.example.demo.constant.UserProjectHistoryStatus;
 import com.example.demo.dto.user.response.UserProjectHistoryInfoResponseDto;
+import com.example.demo.model.project.QProjectMember;
+import com.example.demo.model.trust_grade.QTrustGrade;
+import com.example.demo.model.user.UserProjectHistory;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -52,5 +57,47 @@ public class UserProjectHistoryRepositoryImpl implements UserProjectHistoryRepos
                         .fetch();
 
         return content;
+    }
+
+    @Override
+    public Long countParticipatesUserProjectHistoryByUserId(Long userId) {
+        // 회원 참여중인 프로젝트 이력 개수 조회
+        return jpaQueryFactory
+                .select(userProjectHistory.count())
+                .from(userProjectHistory)
+                .where(getPredicateForUserAndUserProjectHistoryStatus(userId))
+                .fetchOne();
+    }
+
+    @Override
+    public List<UserProjectHistory> findAllUserParticipates(Long userId, Pageable pageable) {
+        QTrustGrade qTrustGrade = QTrustGrade.trustGrade;
+        QProjectMember qProjectMember = QProjectMember.projectMember;
+
+        List<UserProjectHistory> results = jpaQueryFactory
+                .selectFrom(userProjectHistory)
+                .join(userProjectHistory.project, project)
+                .join(project.trustGrade, qTrustGrade)
+                .join(project.projectMembers, qProjectMember)
+                .join(qProjectMember.user, user)
+                .where(getPredicateForUserAndUserProjectHistoryStatus(userId))
+                .orderBy(userProjectHistory.startDate.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return results;
+    }
+
+    private BooleanBuilder getPredicateForUserAndUserProjectHistoryStatus(Long userId) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if(userId != null) {
+            builder.and(user.id.eq(userId));
+        }
+
+        builder.and(userProjectHistory.status.eq(UserProjectHistoryStatus.PARTICIPATING));
+
+        return builder;
     }
 }

--- a/src/main/java/com/example/demo/service/project/ProjectFacade.java
+++ b/src/main/java/com/example/demo/service/project/ProjectFacade.java
@@ -9,19 +9,24 @@ import com.example.demo.dto.project.response.ProjectSpecificDetailResponseDto;
 import com.example.demo.dto.projectmember.response.MyProjectMemberResponseDto;
 import com.example.demo.dto.trust_grade.response.TrustGradeResponseDto;
 import com.example.demo.dto.user.response.UserMyProjectResponseDto;
+import com.example.demo.global.exception.customexception.PageNationCustomException;
 import com.example.demo.model.alert.Alert;
 import com.example.demo.model.position.Position;
 import com.example.demo.model.project.Project;
 import com.example.demo.model.project.ProjectMember;
 import com.example.demo.model.project.ProjectMemberAuth;
 import com.example.demo.model.user.User;
+import com.example.demo.model.user.UserProjectHistory;
 import com.example.demo.service.alert.AlertService;
 import com.example.demo.service.milestone.MilestoneService;
 import com.example.demo.service.position.PositionService;
+import com.example.demo.service.user.UserProjectHistoryService;
 import com.example.demo.service.user.UserService;
 import com.example.demo.service.work.WorkService;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,6 +44,42 @@ public class ProjectFacade {
     private final AlertService alertService;
     private final ProjectMemberAuthService projectMemberAuthService;
     private final MilestoneService milestoneService;
+    private final UserProjectHistoryService userProjectHistoryService;
+
+    @Transactional(readOnly = true)
+    public ProjectPaginationResponseDto getMyProjectsParticipates(Long userId, int pageIndex, int itemCount) {
+        User user = userService.findById(userId);
+
+        if(pageIndex < 0) {
+            throw PageNationCustomException.INVALID_PAGE_NUMBER;
+        }
+
+        if(itemCount < 1 && itemCount > 6) {
+            throw PageNationCustomException.INVALID_PAGE_ITEM_COUNT;
+        }
+
+        // 참여중인 프로젝트 개수 조회
+        long totalPages = userProjectHistoryService.getUserProjectHistoryParticipatesTotalCount(user.getId());
+
+        // 내가 참여중인 프로젝트 이력 목록 불러오기 (정렬, 페이징)
+        List<UserProjectHistory> projectHistories = userProjectHistoryService.getUserProjectHistoryListParticipates(userId, pageIndex, itemCount);
+
+        // 내가 참여중인 프로젝트 목록
+        List<Project> projects = projectHistories.stream()
+                .map(userProjectHistory -> userProjectHistory.getProject())
+                .collect(Collectors.toList());
+
+        List<ProjectMeResponseDto> content = new ArrayList<>();
+        for(Project project : projects) {
+            List<MyProjectMemberResponseDto> myProjectMembers = project.getProjectMembers().stream()
+                    .map(projectMember -> MyProjectMemberResponseDto.of(projectMember, UserMyProjectResponseDto.of(projectMember.getUser())))
+                    .collect(Collectors.toList());
+
+            content.add(ProjectMeResponseDto.of(project, TrustGradeResponseDto.of(project.getTrustGrade()), myProjectMembers));
+        }
+
+        return ProjectPaginationResponseDto.of(content, totalPages);
+    }
 
     /**
      * 내 프로젝트 목록 조회

--- a/src/main/java/com/example/demo/service/user/UserProjectHistoryService.java
+++ b/src/main/java/com/example/demo/service/user/UserProjectHistoryService.java
@@ -19,4 +19,10 @@ public interface UserProjectHistoryService {
 
     // 회원 프로젝트 이력 조회
     List<UserProjectHistoryInfoResponseDto> getUserProjectHistoryList(Long userId, int pageNumber);
+
+    // 회원 참여중인 프로젝트 이력 조회
+    List<UserProjectHistory> getUserProjectHistoryListParticipates(Long userId, int pageIndex, int itemCount);
+
+    // 회원 참여중인 프로젝트 이력 개수 조회
+    Long getUserProjectHistoryParticipatesTotalCount(Long userId);
 }

--- a/src/main/java/com/example/demo/service/user/UserProjectHistoryServiceImpl.java
+++ b/src/main/java/com/example/demo/service/user/UserProjectHistoryServiceImpl.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -45,5 +46,16 @@ public class UserProjectHistoryServiceImpl implements UserProjectHistoryService 
         PageRequest pageRequest = PageRequest.of(pageNumber, 5);
         return userProjectHistoryRepository.findAllByUserIdOrderByUpdateDateDesc(
                 userId, pageRequest);
+    }
+
+    @Override
+    public List<UserProjectHistory> getUserProjectHistoryListParticipates(Long userId, int pageIndex, int itemCount) {
+        Pageable pageable = PageRequest.of(pageIndex, itemCount);
+        return userProjectHistoryRepository.findAllUserParticipates(userId, pageable);
+    }
+
+    @Override
+    public Long getUserProjectHistoryParticipatesTotalCount(Long userId) {
+        return userProjectHistoryRepository.countParticipatesUserProjectHistoryByUserId(userId);
     }
 }


### PR DESCRIPTION
### 작업내용
- 요구사항 변경으로 요청한 회원이 참여중인 프로젝트 목록을 조회하는 로직 구현
- 요청한 회원의 ID(PK), pageIndex, itemCount 값으로 해당 회원의 프로젝트 이력 중 참여중인 이력을 페이징 처리해 조회하고 해당 프로젝트들의 정보를 응답하도록 구현
- 페이징 처리한 프로젝트들의 정보를 담은 List 타입의 content, 해당 회원이 참여중인 총 프로젝트 개수를 담은 long 타입의 totalPages 데이터를 ProjectPaginationResponseDto로 응답


### 연관이슈
close #304 