### PR TITLE
[feature/fix-create-work] 업무 생성 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/controller/work/WorkController.java
+++ b/src/main/java/com/example/demo/controller/work/WorkController.java
@@ -26,10 +26,11 @@ public class WorkController {
 
     @PostMapping("/api/work/project/{projectId}/milestone/{milestoneId}")
     public ResponseEntity<ResponseDto<?>> create(
+            @AuthenticationPrincipal PrincipalDetails user,
             @PathVariable("projectId") Long projectId,
             @PathVariable("milestoneId") Long milestoneId,
             @RequestBody WorkCreateRequestDto workCreateRequestDto) {
-        workFacade.create(projectId, milestoneId, workCreateRequestDto);
+        workFacade.create(user.getId(), projectId, milestoneId, workCreateRequestDto);
         return new ResponseEntity<>(ResponseDto.success("success"), HttpStatus.OK);
     }
 

--- a/src/main/java/com/example/demo/service/work/WorkFacade.java
+++ b/src/main/java/com/example/demo/service/work/WorkFacade.java
@@ -32,13 +32,16 @@ public class WorkFacade {
     private final ProjectMemberService projectMemberService;
 
     public void create(
-            Long projectId, Long milestoneId, WorkCreateRequestDto workCreateRequestDto) {
+            Long userId, Long projectId, Long milestoneId, WorkCreateRequestDto workCreateRequestDto) {
         Project project = projectService.findById(projectId);
         Milestone milestone = milestoneService.findById(milestoneId);
-        User user = userService.findById(workCreateRequestDto.getAssignedUserId());
+        User user = userService.findById(userId);
         ProjectMember projectMember =
                 projectMemberService.findProjectMemberByProjectAndUser(project, user);
-        Work work = workCreateRequestDto.toWorkEntity(project, milestone, user, projectMember);
+
+        ProjectMember assignedProjectMember = projectMemberService.findById(workCreateRequestDto.getAssignedUserId());
+
+        Work work = workCreateRequestDto.toWorkEntity(project, milestone, assignedProjectMember.getUser(), projectMember);
 
         workService.save(work);
     }


### PR DESCRIPTION
### 작업내용
- 업무 생성 시 요청한 회원의 인증 정보를 파라미터로 받도록 수정
- 업무 생성 시 업무 엔티티의 lastModifiedMember 정보를 요청한 회원 정보와 해당 프로젝트 정보로 조회해 저장하도록 수정 
- 업무 생성 요청 데이터 중 assignedUserId 데이터가 ProjectMember 엔티티의 ID(PK)로 요청하여 할당 사용자 정보를 저장하는 로직을 ProjectMember 엔티티의 User 엔티티 값을 저장하도록 수정