### PR TITLE
[feature/268-categories-by-tech-stacks] 모든 기술스택 별 카테고리를 함께 조회하는 로직 구현

### DIFF
--- a/src/main/java/com/example/demo/controller/technology_stack/TechnologyStackCategoryMappingController.java
+++ b/src/main/java/com/example/demo/controller/technology_stack/TechnologyStackCategoryMappingController.java
@@ -1,0 +1,21 @@
+package com.example.demo.controller.technology_stack;
+
+import com.example.demo.dto.common.ResponseDto;
+import com.example.demo.service.technology_stack.TechnologyStackCategoryMappingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TechnologyStackCategoryMappingController {
+
+    private final TechnologyStackCategoryMappingService technologyStackCategoryMappingService;
+
+    @GetMapping("/api/technology-stack-category-mapping-list/public")
+    public ResponseEntity<ResponseDto<?>> getTechnologyStacksWithCategories() {
+        return ResponseEntity.status(HttpStatus.OK).body(technologyStackCategoryMappingService.getCategoriesByTechStacks());
+    }
+}

--- a/src/main/java/com/example/demo/dto/technology_stack/response/TechnologyStackWithCategoriesResponseDto.java
+++ b/src/main/java/com/example/demo/dto/technology_stack/response/TechnologyStackWithCategoriesResponseDto.java
@@ -1,0 +1,25 @@
+package com.example.demo.dto.technology_stack.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class TechnologyStackWithCategoriesResponseDto {
+
+    private Long techStackId;
+    private String techStackName;
+    private List<String> categories;
+
+    public static TechnologyStackWithCategoriesResponseDto of(Long techStackId, String techStackName, List<String> categories) {
+        return TechnologyStackWithCategoriesResponseDto.builder()
+                .techStackId(techStackId)
+                .techStackName(techStackName)
+                .categories(categories)
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/repository/technology_stack/TechnologyStackCategoryMappingRepository.java
+++ b/src/main/java/com/example/demo/repository/technology_stack/TechnologyStackCategoryMappingRepository.java
@@ -1,0 +1,7 @@
+package com.example.demo.repository.technology_stack;
+
+import com.example.demo.model.technology_stack.TechnologyStackCategoryMapping;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TechnologyStackCategoryMappingRepository extends JpaRepository<TechnologyStackCategoryMapping, Long>, TechnologyStackCategoryMappingRepositoryCustom {
+}

--- a/src/main/java/com/example/demo/repository/technology_stack/TechnologyStackCategoryMappingRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/technology_stack/TechnologyStackCategoryMappingRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.example.demo.repository.technology_stack;
+
+import com.example.demo.dto.technology_stack.response.TechnologyStackWithCategoriesResponseDto;
+
+import java.util.List;
+
+public interface TechnologyStackCategoryMappingRepositoryCustom {
+
+    // 각 기술스택 별 카테고리 정보를 포함해 모든 기술스택 조회
+    List<TechnologyStackWithCategoriesResponseDto> findAllTechnologyStacksAndCategories();
+}

--- a/src/main/java/com/example/demo/repository/technology_stack/TechnologyStackCategoryMappingRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/technology_stack/TechnologyStackCategoryMappingRepositoryImpl.java
@@ -1,0 +1,68 @@
+package com.example.demo.repository.technology_stack;
+
+import com.example.demo.dto.technology_stack.response.TechnologyStackWithCategoriesResponseDto;
+import com.example.demo.model.technology_stack.QTechnologyStack;
+import com.example.demo.model.technology_stack.QTechnologyStackCategory;
+import com.example.demo.model.technology_stack.QTechnologyStackCategoryMapping;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+
+@Repository
+@RequiredArgsConstructor
+public class TechnologyStackCategoryMappingRepositoryImpl implements TechnologyStackCategoryMappingRepositoryCustom{
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QTechnologyStack qTechnologyStack = QTechnologyStack.technologyStack;
+    private final QTechnologyStackCategory qTechnologyStackCategory = QTechnologyStackCategory.technologyStackCategory;
+    private final QTechnologyStackCategoryMapping qTechnologyStackCategoryMapping = QTechnologyStackCategoryMapping.technologyStackCategoryMapping;
+
+    @Override
+    public List<TechnologyStackWithCategoriesResponseDto> findAllTechnologyStacksAndCategories() {
+       List<Tuple> tuples = jpaQueryFactory
+               .select(qTechnologyStack.id, qTechnologyStack.name, qTechnologyStackCategory.name)
+               .from(qTechnologyStackCategoryMapping)
+               .join(qTechnologyStackCategoryMapping.technologyStack, qTechnologyStack)
+               .join(qTechnologyStackCategoryMapping.category, qTechnologyStackCategory)
+               .fetch();
+
+       // 조회한 기술스택 정보를 ID, name 형태로 Map 으로 관리
+       Map<Long, String> techStackNames = tuples.stream()
+               .collect(Collectors.toMap(
+                       tuple -> tuple.get(qTechnologyStack.id),
+                       tuple -> tuple.get(qTechnologyStack.name),
+                       (name1, name2) -> name1
+               ));
+
+       // 조회한 기술스택, 카테고리 결과를 기술스택 ID를 기준으로 그룹화를 진행하고 TechnologyStackWithCategoriesResponseDto 셋팅
+       List<TechnologyStackWithCategoriesResponseDto> results = tuples.stream()
+               .collect(Collectors.collectingAndThen(
+                       Collectors.groupingBy(
+                               tuple -> tuple.get(qTechnologyStack.id),
+                               Collectors.mapping(
+                                       tuple -> tuple.get(qTechnologyStackCategory.name),
+                                       Collectors.toList()
+                               )
+                       ),
+                       techStacksWithCategories -> techStacksWithCategories.entrySet().stream()
+                               .map(entry -> {
+                                   Long techStackId = entry.getKey();
+                                   String techStackName = techStackNames.getOrDefault(techStackId, "");
+                                   List<String> categories = entry.getValue();
+
+                                   return TechnologyStackWithCategoriesResponseDto.of(techStackId, techStackName, categories);
+                               })
+                               .collect(Collectors.toList())
+               ));
+
+       return results;
+    }
+}

--- a/src/main/java/com/example/demo/service/technology_stack/TechnologyStackCategoryMappingService.java
+++ b/src/main/java/com/example/demo/service/technology_stack/TechnologyStackCategoryMappingService.java
@@ -1,0 +1,9 @@
+package com.example.demo.service.technology_stack;
+
+import com.example.demo.dto.common.ResponseDto;
+
+public interface TechnologyStackCategoryMappingService {
+
+    // 모든 기술스택 별 카테고리 조회
+    ResponseDto<?> getCategoriesByTechStacks();
+}

--- a/src/main/java/com/example/demo/service/technology_stack/TechnologyStackCategoryMappingServiceImpl.java
+++ b/src/main/java/com/example/demo/service/technology_stack/TechnologyStackCategoryMappingServiceImpl.java
@@ -1,0 +1,22 @@
+package com.example.demo.service.technology_stack;
+
+import com.example.demo.dto.common.ResponseDto;
+import com.example.demo.dto.technology_stack.response.TechnologyStackWithCategoriesResponseDto;
+import com.example.demo.repository.technology_stack.TechnologyStackCategoryMappingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TechnologyStackCategoryMappingServiceImpl implements TechnologyStackCategoryMappingService{
+
+    private final TechnologyStackCategoryMappingRepository technologyStackCategoryMappingRepository;
+
+    @Override
+    public ResponseDto<?> getCategoriesByTechStacks() {
+        List<TechnologyStackWithCategoriesResponseDto> techStacks = technologyStackCategoryMappingRepository.findAllTechnologyStacksAndCategories();
+        return ResponseDto.success("모든 기술스택별 카테고리 목록 조회가 완료되었습니다.", techStacks);
+    }
+}


### PR DESCRIPTION
### 작업내용
- 기술스택과 기술스택 카테고리를 관리하는 TechnologyStackCategoryMapping 테이블에서 모든 기술스택 별 카테고리들을 함께 조회하는 로직 구현
- 하나의 기술스택 당 여러개의 카테고리를 가질 수 있어 모든 TechnologyStackCategoryMapping 데이터를 조회해technology_stack_id(기술스택 ID(PK))를 기준으로 그룹핑하고 기술스택 ID와 기술스택 이름, 해당 기술스택에 포함된 카테고리 목록을 List에 담아 TechnologyStackWithCategoriesResponse DTO로 응답하도록 구현

- 응답 값
```
"data": [
     {
          "techStackId": 20,
          "techStackName": "ReactNative",
          "categories": [
              "백엔드"
          ]
      },
      {
          "techStackId": 21,
          "techStackName": "Unity",
          "categories": [
              "IOS",
              "안드로이드"
          ]
      },
      {
          "techStackId": 22,
          "techStackName": "Flutter",
          "categories": [
              "IOS",
              "안드로이드",
              "기타"
          ]
      }
]
```



### 연관이슈
close #268 