### PR TITLE
[feature/287-fix-project-member-detail-response] 프로젝트 멤버 상세 조회 응답 데이터 수정

### DIFF
--- a/src/main/java/com/example/demo/dto/projectmember/response/ProjectMemberReadCrewDetailResponseDto.java
+++ b/src/main/java/com/example/demo/dto/projectmember/response/ProjectMemberReadCrewDetailResponseDto.java
@@ -14,7 +14,7 @@ public class ProjectMemberReadCrewDetailResponseDto {
     private Long projectId;
     private int projectCount;
     private UserCrewDetailResponseDto user;
-    private Long projectMemberAuthId;
+    private ProjectMemberAuthResponseDto projectMemberAuth;
     private PositionResponseDto position;
     private ProjectMemberStatus status;
 
@@ -22,13 +22,14 @@ public class ProjectMemberReadCrewDetailResponseDto {
             ProjectMember projectMember,
             int projectCount,
             UserCrewDetailResponseDto user,
+            ProjectMemberAuthResponseDto projectMemberAuth,
             PositionResponseDto position) {
         return ProjectMemberReadCrewDetailResponseDto.builder()
                 .projectMemberId(projectMember.getId())
                 .projectId(projectMember.getProject().getId())
                 .projectCount(projectCount)
                 .user(user)
-                .projectMemberAuthId(projectMember.getProjectMemberAuth().getId())
+                .projectMemberAuth(projectMemberAuth)
                 .position(position)
                 .status(projectMember.getStatus())
                 .build();

--- a/src/main/java/com/example/demo/service/project/ProjectMemberFacade.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberFacade.java
@@ -82,17 +82,19 @@ public class ProjectMemberFacade {
             technologyStackInfoResponseDtoList.add(technologyStackInfoResponseDto);
         }
 
-        // 임시
         UserCrewDetailResponseDto userCrewDetailResponseDto =
                 UserCrewDetailResponseDto.of(
                         projectMember.getUser(),
-                        1,
+                        projectMember.getUser().getTrustScore().getScore(),
                         positionResponseDto,
                         trustGradeResponseDto,
                         technologyStackInfoResponseDtoList);
 
+        ProjectMemberAuthResponseDto projectMemberAuthResponse =
+                ProjectMemberAuthResponseDto.of(projectMember.getProjectMemberAuth());
+
         return ProjectMemberReadCrewDetailResponseDto.of(
-                projectMember, projectCount, userCrewDetailResponseDto, positionResponseDto);
+                projectMember, projectCount, userCrewDetailResponseDto, projectMemberAuthResponse, positionResponseDto);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
### 작업내용
- 프론트단에서 사용자가 프로젝트 멤버의 권한 정보를 확인해야 하므로 기존 프로젝트 멤버 상세 조회 응답 시 Long 타입의 projectMemberAuthId 정보를 ProjectMemberAuthResponseDto 타입으로 응답하도록 변경하고 필드명 수정
- 프로젝트 멤버 상세 정보를 조회하는 로직에서 ProjectMemberAuthResponseDto 데이터를 셋팅하고 응답하도록 수정
- 프로젝트 멤버 신뢰점수를 고정된 값을 셋팅하는 코드 수정



### 연관이슈
close #287 
