### PR TITLE
[feature/288-project-member-works-with-trust-score] 특정 프로젝트 멤버의 업무 이력과 업무 별 신뢰점수 내역 조회 로직 구현

### DIFF
--- a/src/main/java/com/example/demo/controller/project/ProjectMemberController.java
+++ b/src/main/java/com/example/demo/controller/project/ProjectMemberController.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Optional;
+
 @RestController
 @RequestMapping("/api/projectmember")
 @AllArgsConstructor
@@ -54,4 +56,14 @@ public class ProjectMemberController {
                 projectMemberFacade.getCrewsByProject(projectId);
         return new ResponseEntity<>(ResponseDto.success("success", result), HttpStatus.OK);
     }
+
+    // 프로젝트 멤버 업무 이력 조회
+    @GetMapping("/{projectMemberId}/works")
+    public ResponseEntity<ResponseDto<?>> getCrewWorksWithTrustScoreHistory(
+            @PathVariable("projectMemberId") Long projectMemberId,
+            @RequestParam("pageIndex") Optional<Integer> pageIndex,
+            @RequestParam("itemCount") Optional<Integer> itemCount) {
+        return new ResponseEntity<>(ResponseDto.success("success", projectMemberFacade.getCrewWorksWithTrustScoreHistory(projectMemberId, pageIndex.orElse(0), itemCount.orElse(5))), HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/example/demo/dto/projectmember/response/ProjectMemberWorkWithTrustScoreResponseDto.java
+++ b/src/main/java/com/example/demo/dto/projectmember/response/ProjectMemberWorkWithTrustScoreResponseDto.java
@@ -1,0 +1,28 @@
+package com.example.demo.dto.projectmember.response;
+
+import com.example.demo.constant.ProgressStatus;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+@Getter
+public class ProjectMemberWorkWithTrustScoreResponseDto {
+
+    private String content;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String progressStatus;
+    private Integer point;
+    private String point_type;
+
+    public ProjectMemberWorkWithTrustScoreResponseDto(String content, LocalDate startDate,
+                                                      LocalDate endDate, ProgressStatus progressStatus, Integer point, String point_type) {
+        this.content = content;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.progressStatus = progressStatus.getDescription();
+        this.point = point;
+        this.point_type = Objects.nonNull(point_type) ? (point_type.equals("M") ? "minus" : "plus") : null;
+    }
+}

--- a/src/main/java/com/example/demo/dto/projectmember/response/ProjectMemberWorkWithTrustScoreResponseDto.java
+++ b/src/main/java/com/example/demo/dto/projectmember/response/ProjectMemberWorkWithTrustScoreResponseDto.java
@@ -9,16 +9,16 @@ import java.util.Objects;
 @Getter
 public class ProjectMemberWorkWithTrustScoreResponseDto {
 
-    private String content;
+    private String workContent;
     private LocalDate startDate;
     private LocalDate endDate;
     private String progressStatus;
     private Integer point;
     private String point_type;
 
-    public ProjectMemberWorkWithTrustScoreResponseDto(String content, LocalDate startDate,
+    public ProjectMemberWorkWithTrustScoreResponseDto(String workContent, LocalDate startDate,
                                                       LocalDate endDate, ProgressStatus progressStatus, Integer point, String point_type) {
-        this.content = content;
+        this.workContent = workContent;
         this.startDate = startDate;
         this.endDate = endDate;
         this.progressStatus = progressStatus.getDescription();

--- a/src/main/java/com/example/demo/dto/projectmember/response/ProjectMemberWorksPaginationResponseDto.java
+++ b/src/main/java/com/example/demo/dto/projectmember/response/ProjectMemberWorksPaginationResponseDto.java
@@ -1,0 +1,21 @@
+package com.example.demo.dto.projectmember.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ProjectMemberWorksPaginationResponseDto {
+
+    private List<ProjectMemberWorkWithTrustScoreResponseDto> content;
+    private long totalPages;
+
+    public static ProjectMemberWorksPaginationResponseDto of(List<ProjectMemberWorkWithTrustScoreResponseDto> content, long totalPages) {
+        return ProjectMemberWorksPaginationResponseDto.builder()
+                .content(content)
+                .totalPages(totalPages)
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/repository/work/WorkRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/work/WorkRepositoryCustom.java
@@ -1,12 +1,14 @@
 package com.example.demo.repository.work;
 
+import com.example.demo.dto.projectmember.response.ProjectMemberWorksPaginationResponseDto;
 import com.example.demo.dto.work.response.WorkPaginationResponseDto;
 import org.springframework.data.domain.Pageable;
-
-import java.util.List;
 
 public interface WorkRepositoryCustom {
 
     // 프로젝트 > 마일스톤 > 업무 리스트 조회 (시작날짜 기준 오름차순 정렬, 페이징)
     WorkPaginationResponseDto findWorkByProjectIdAndMilestoneIdOrderByStartDateAsc(Long projectId, Long milestoneId, Pageable pageable);
+
+    // 특정 프로젝트에 할당된 프로젝트 멤버의 업무 내역 + 업무 별 신뢰점수 내역 조회 (시작날짜 기준 최신순 정렬, 페이징)
+    ProjectMemberWorksPaginationResponseDto findWorksWithTrustScoreHistoryByProjectIdAndAssignedUserIdOrderByStartDateDesc(Long projectId, Long assignedUserId, Pageable pageable);
 }

--- a/src/main/java/com/example/demo/repository/work/WorkRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/work/WorkRepositoryImpl.java
@@ -60,19 +60,20 @@ public class WorkRepositoryImpl implements WorkRepositoryCustom{
                 .fetch();
 
         // 업무 전체 갯수 조회
-        long totalPages = getTotalItemCount(projectId, milestoneId);
+        long totalPages = getTotalItemCount(projectId, milestoneId, null);
 
         return WorkPaginationResponseDto.of(content, totalPages);
     }
 
     // 조건에 맞는 업무의 총 개수 조회
-    private Long getTotalItemCount(Long projectId, Long milestoneId) {
+    private Long getTotalItemCount(Long projectId, Long milestoneId, Long assignedUserId) {
         return jpaQueryFactory
                 .select(qWork.count())
                 .from(qWork)
                 .where(
                         eqProjectId(projectId),
-                        eqMilestoneId(milestoneId)
+                        eqMilestoneId(milestoneId),
+                        eqAssignedUserId(assignedUserId)
                 )
                 .fetchOne();
     }

--- a/src/main/java/com/example/demo/repository/work/WorkRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/work/WorkRepositoryImpl.java
@@ -1,10 +1,14 @@
 package com.example.demo.repository.work;
 
+import com.example.demo.dto.projectmember.response.ProjectMemberWorksPaginationResponseDto;
+import com.example.demo.dto.projectmember.response.ProjectMemberWorkWithTrustScoreResponseDto;
 import com.example.demo.dto.work.response.WorkPaginationResponseDto;
 import com.example.demo.dto.work.response.WorkReadResponseDto;
 import com.example.demo.model.milestone.QMilestone;
 import com.example.demo.model.project.QProject;
 import com.example.demo.model.project.QProjectMember;
+import com.example.demo.model.trust_score.QTrustScoreHistory;
+import com.example.demo.model.trust_score.QTrustScoreType;
 import com.example.demo.model.user.QUser;
 import com.example.demo.model.work.QWork;
 import com.querydsl.core.types.Projections;
@@ -26,6 +30,8 @@ public class WorkRepositoryImpl implements WorkRepositoryCustom{
     private final QWork qWork = QWork.work;
     private final QUser qUser = QUser.user;
     private final QProjectMember qProjectMember = QProjectMember.projectMember;
+    private final QTrustScoreHistory qTrustScoreHistory = QTrustScoreHistory.trustScoreHistory;
+    private final QTrustScoreType qTrustScoreType = QTrustScoreType.trustScoreType;
 
     @Override
     public WorkPaginationResponseDto findWorkByProjectIdAndMilestoneIdOrderByStartDateAsc(Long projectId, Long milestoneId, Pageable pageable) {
@@ -63,6 +69,39 @@ public class WorkRepositoryImpl implements WorkRepositoryCustom{
         long totalPages = getTotalItemCount(projectId, milestoneId, null);
 
         return WorkPaginationResponseDto.of(content, totalPages);
+    }
+
+    @Override
+    public ProjectMemberWorksPaginationResponseDto findWorksWithTrustScoreHistoryByProjectIdAndAssignedUserIdOrderByStartDateDesc(Long projectId, Long assignedUserId, Pageable pageable) {
+        // 프로젝트 멤버 업무 목록 + 업무 별 신뢰점수 내역 조회
+        List<ProjectMemberWorkWithTrustScoreResponseDto> content = jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                ProjectMemberWorkWithTrustScoreResponseDto.class,
+                                qWork.content,
+                                qWork.startDate,
+                                qWork.endDate,
+                                qWork.progressStatus,
+                                qTrustScoreType.score,
+                                qTrustScoreType.gubunCode
+                        )
+                )
+                .from(qWork)
+                .leftJoin(qTrustScoreHistory).on(qWork.id.eq(qTrustScoreHistory.workId))
+                .leftJoin(qTrustScoreType).on(qTrustScoreHistory.trustScoreTypeId.eq(qTrustScoreType.id))
+                .where(
+                        eqProjectId(projectId),
+                        eqAssignedUserId(assignedUserId)
+                )
+                .orderBy(qWork.startDate.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 업무 전체 갯수 조회
+        long totalPages = getTotalItemCount(projectId, null, assignedUserId);
+
+        return ProjectMemberWorksPaginationResponseDto.of(content, totalPages);
     }
 
     // 조건에 맞는 업무의 총 개수 조회

--- a/src/main/java/com/example/demo/repository/work/WorkRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/work/WorkRepositoryImpl.java
@@ -7,7 +7,6 @@ import com.example.demo.model.project.QProject;
 import com.example.demo.model.project.QProjectMember;
 import com.example.demo.model.user.QUser;
 import com.example.demo.model.work.QWork;
-import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -94,5 +93,14 @@ public class WorkRepositoryImpl implements WorkRepositoryCustom{
         }
 
         return qWork.milestone.id.eq(milestoneId);
+    }
+
+    // 할당자 ID 비교
+    private BooleanExpression eqAssignedUserId(Long assignedUserId) {
+        if(assignedUserId == null) {
+            return null;
+        }
+
+        return qWork.assignedUserId.id.eq(assignedUserId);
     }
 }

--- a/src/main/java/com/example/demo/service/project/ProjectMemberFacade.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberFacade.java
@@ -7,6 +7,7 @@ import com.example.demo.dto.technology_stack.response.TechnologyStackInfoRespons
 import com.example.demo.dto.trust_grade.response.TrustGradeResponseDto;
 import com.example.demo.dto.user.response.UserCrewDetailResponseDto;
 import com.example.demo.dto.user.response.UserReadProjectCrewResponseDto;
+import com.example.demo.global.exception.customexception.PageNationCustomException;
 import com.example.demo.model.alert.Alert;
 import com.example.demo.model.project.Project;
 import com.example.demo.model.project.ProjectMember;
@@ -19,6 +20,7 @@ import com.example.demo.service.work.WorkService;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -126,6 +128,31 @@ public class ProjectMemberFacade {
         ProjectMemberReadTotalProjectCrewsResponseDto result =
                 ProjectMemberReadTotalProjectCrewsResponseDto.of(
                         projectMemberReadProjectCrewsResponseDtos);
+        return result;
+    }
+
+    /**
+     * 프로젝트 멤버가 할당된 업무 이력 + 업무 별 신뢰점수 내역 조회
+     * @param projectMemberId
+     * @param pageIndex
+     * @param itemCount
+     * @return ProjectMemberWorkPaginationResponseDto
+     */
+    @Transactional(readOnly = true)
+    public ProjectMemberWorksPaginationResponseDto getCrewWorksWithTrustScoreHistory(Long projectMemberId, int pageIndex, int itemCount) {
+        if(pageIndex < 0) {
+            throw PageNationCustomException.INVALID_PAGE_NUMBER;
+        }
+
+        if(itemCount < 0 || itemCount > 6) {
+            throw PageNationCustomException.INVALID_PAGE_ITEM_COUNT;
+        }
+
+        ProjectMember projectMember = projectMemberService.findById(projectMemberId);
+
+        // 해당 프로젝트 멤버의 업무 + 업무 별 신뢰점수 내역 & 해당 프로젝트 멤버 업무 총 개수 조회
+        ProjectMemberWorksPaginationResponseDto result = workService.findWorksWithTrustScoreHistoryByProjectIdAndAssignedUserId(projectMember.getProject().getId(), projectMember.getUser().getId(), PageRequest.of(pageIndex, itemCount));
+
         return result;
     }
 }

--- a/src/main/java/com/example/demo/service/work/WorkService.java
+++ b/src/main/java/com/example/demo/service/work/WorkService.java
@@ -1,8 +1,8 @@
 package com.example.demo.service.work;
 
+import com.example.demo.dto.projectmember.response.ProjectMemberWorksPaginationResponseDto;
 import com.example.demo.dto.work.response.WorkPaginationResponseDto;
 import com.example.demo.dto.work.response.WorkReadResponseDto;
-import com.example.demo.model.milestone.Milestone;
 import com.example.demo.model.project.Project;
 import com.example.demo.model.user.User;
 import com.example.demo.model.work.Work;
@@ -27,4 +27,7 @@ public interface WorkService {
     public WorkReadResponseDto getOne(Long workId);
 
     public void delete(Long workId);
+
+    // 특정 프로젝트에 할당된 특정 회원의 업무 내역 + 업무 신뢰점수 내역 조회
+    ProjectMemberWorksPaginationResponseDto findWorksWithTrustScoreHistoryByProjectIdAndAssignedUserId(Long projectId, Long assignedUserId, Pageable pageable);
 }

--- a/src/main/java/com/example/demo/service/work/WorkServiceImpl.java
+++ b/src/main/java/com/example/demo/service/work/WorkServiceImpl.java
@@ -1,10 +1,10 @@
 package com.example.demo.service.work;
 
 import com.example.demo.constant.ProgressStatus;
+import com.example.demo.dto.projectmember.response.ProjectMemberWorksPaginationResponseDto;
 import com.example.demo.dto.work.response.WorkPaginationResponseDto;
 import com.example.demo.dto.work.response.WorkReadResponseDto;
 import com.example.demo.global.exception.customexception.WorkCustomException;
-import com.example.demo.model.milestone.Milestone;
 import com.example.demo.model.project.Project;
 import com.example.demo.model.user.User;
 import com.example.demo.model.work.Work;
@@ -54,5 +54,10 @@ public class WorkServiceImpl implements WorkService {
     public void delete(Long workId) {
         Work work = findById(workId);
         workRepository.delete(work);
+    }
+
+    @Override
+    public ProjectMemberWorksPaginationResponseDto findWorksWithTrustScoreHistoryByProjectIdAndAssignedUserId(Long projectId, Long assignedUserId, Pageable pageable) {
+        return workRepository.findWorksWithTrustScoreHistoryByProjectIdAndAssignedUserIdOrderByStartDateDesc(projectId, assignedUserId, pageable);
     }
 }


### PR DESCRIPTION
### 작업내용
- 요구사항을 반영하여 특정 프로젝트의 프로젝트 크루 상세 정보 페이지에서 해당 프로젝트 크루의 업무 이력과 각 업무 별 신뢰점수 내역을 조회할 수 있는 로직 구현
- 요청한 프로젝트 크루 ID(PK) 값으로 해당 프로젝트 크루가 속한 프로젝트 정보, 프로젝트 크루의 회원 정보로 조건에 맞는 데이터를 조회하도록 구현
- 각 업무별 데이터를 ProjectMemberWorkWithTrustScoreResponseDto(업무내용, 업무 시작날짜, 업무 종료날짜, 업무 진행상태, 업무에서 부여받은 신뢰점수, 업무 신뢰점수 타입)에 셋팅하고 ProjectMemberWorksPaginationResponseDto으로 총 업무 개수와 함께 응답
- 업무의 상태가 '시작전', '진행중'인 경우 해당 업무에 대한 신뢰점수 내역이 존재하지 않기 때문에 응답 시 'point', 'point_type' 필드에 null 값을 응답
- pageIndex, itemCount 페이징 관련 요청 데이터를 받아 조건에 맞도록 페이징 작업을 처리



### 연관이슈
close #288 