### PR TITLE
[feature/314-fix-get-user-project-history-response] 회원 프로젝트 이력 목록 조회 시 응답 형태 수정

### DIFF
--- a/src/main/java/com/example/demo/dto/user/response/UserProjectHistoryPaginationResponseDto.java
+++ b/src/main/java/com/example/demo/dto/user/response/UserProjectHistoryPaginationResponseDto.java
@@ -1,0 +1,21 @@
+package com.example.demo.dto.user.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class UserProjectHistoryPaginationResponseDto {
+
+    private List<UserProjectHistoryInfoResponseDto> content;
+    private long totalPages;
+
+    public static UserProjectHistoryPaginationResponseDto of(List<UserProjectHistoryInfoResponseDto> content, long totalPages) {
+        return UserProjectHistoryPaginationResponseDto.builder()
+                .content(content)
+                .totalPages(totalPages)
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepositoryCustom.java
@@ -3,17 +3,18 @@ package com.example.demo.repository.user;
 import com.example.demo.dto.user.response.UserProjectHistoryInfoResponseDto;
 import java.util.List;
 
+import com.example.demo.dto.user.response.UserProjectHistoryPaginationResponseDto;
 import com.example.demo.model.user.UserProjectHistory;
 import org.springframework.data.domain.Pageable;
 
 public interface UserProjectHistoryRepositoryCustom {
 
+    // 회원 프로젝트 이력 목록 조회 (수정날짜 기준 최신순 정렬, 페이징 offset 방법 활용)
+    UserProjectHistoryPaginationResponseDto findAllByUserIdOrderByUpdateDateDesc(
+            Long userId, Pageable pageable);
+
     // 회원 프로젝트 이력 전체 개수 조회
     Long countUserProjectHistoryByUserId(Long userId);
-
-    // 회원 프로젝트 이력 목록 조회 (수정날짜 기준 최신순 정렬, 페이징 offset 방법 활용)
-    List<UserProjectHistoryInfoResponseDto> findAllByUserIdOrderByUpdateDateDesc(
-            Long userId, Pageable pageable);
 
     // 회원 참여중인 프로젝트 이력 개수 조회
     Long countParticipatesUserProjectHistoryByUserId(Long userId);

--- a/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepositoryImpl.java
@@ -6,6 +6,7 @@ import static com.example.demo.model.user.QUserProjectHistory.userProjectHistory
 
 import com.example.demo.constant.UserProjectHistoryStatus;
 import com.example.demo.dto.user.response.UserProjectHistoryInfoResponseDto;
+import com.example.demo.dto.user.response.UserProjectHistoryPaginationResponseDto;
 import com.example.demo.model.project.QProjectMember;
 import com.example.demo.model.trust_grade.QTrustGrade;
 import com.example.demo.model.user.UserProjectHistory;
@@ -24,18 +25,7 @@ public class UserProjectHistoryRepositoryImpl implements UserProjectHistoryRepos
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Long countUserProjectHistoryByUserId(Long userId) {
-        // 회원의 전체 프로젝트 이력 개수 조회
-        return jpaQueryFactory
-                .select(userProjectHistory.count())
-                .from(userProjectHistory)
-                .leftJoin(userProjectHistory.user, user)
-                .where(userProjectHistory.user.id.eq(userId))
-                .fetchOne();
-    }
-
-    @Override
-    public List<UserProjectHistoryInfoResponseDto> findAllByUserIdOrderByUpdateDateDesc(
+    public UserProjectHistoryPaginationResponseDto findAllByUserIdOrderByUpdateDateDesc(
             Long userId, Pageable pageable) {
         // 요청한 페이지의 회원 프로젝트 이력 목록 조회
         List<UserProjectHistoryInfoResponseDto> content =
@@ -56,7 +46,21 @@ public class UserProjectHistoryRepositoryImpl implements UserProjectHistoryRepos
                         .limit(pageable.getPageSize())
                         .fetch();
 
-        return content;
+        // 사용자 프로젝트 이력 총 개수 조회
+        long totalPages = countUserProjectHistoryByUserId(userId);
+
+        return UserProjectHistoryPaginationResponseDto.of(content, totalPages);
+    }
+
+    @Override
+    public Long countUserProjectHistoryByUserId(Long userId) {
+        // 회원의 전체 프로젝트 이력 개수 조회
+        return jpaQueryFactory
+                .select(userProjectHistory.count())
+                .from(userProjectHistory)
+                .leftJoin(userProjectHistory.user, user)
+                .where(userProjectHistory.user.id.eq(userId))
+                .fetchOne();
     }
 
     @Override

--- a/src/main/java/com/example/demo/service/user/UserFacade.java
+++ b/src/main/java/com/example/demo/service/user/UserFacade.java
@@ -11,10 +11,7 @@ import com.example.demo.dto.trust_score.AddPointDto;
 import com.example.demo.dto.trust_score.request.TrustScoreUpdateRequestDto;
 import com.example.demo.dto.user.request.UserCreateRequestDto;
 import com.example.demo.dto.user.request.UserUpdateRequestDto;
-import com.example.demo.dto.user.response.UserMyInfoResponseDto;
-import com.example.demo.dto.user.response.UserProjectHistoryInfoResponseDto;
-import com.example.demo.dto.user.response.UserSimpleInfoResponseDto;
-import com.example.demo.dto.user.response.UserUpdateResponseDto;
+import com.example.demo.dto.user.response.*;
 import com.example.demo.global.exception.customexception.PageNationCustomException;
 import com.example.demo.model.position.Position;
 import com.example.demo.model.technology_stack.TechnologyStack;
@@ -303,7 +300,7 @@ public class UserFacade {
             throw PageNationCustomException.INVALID_PAGE_NUMBER;
         }
 
-        List<UserProjectHistoryInfoResponseDto> projectHistoryList =
+        UserProjectHistoryPaginationResponseDto projectHistoryList =
                 userProjectHistoryService.getUserProjectHistoryList(user.getId(), pageNumber);
 
         return ResponseDto.success("내 프로젝트 이력 목록 조회가 완료되었습니다.", projectHistoryList);

--- a/src/main/java/com/example/demo/service/user/UserProjectHistoryService.java
+++ b/src/main/java/com/example/demo/service/user/UserProjectHistoryService.java
@@ -1,6 +1,7 @@
 package com.example.demo.service.user;
 
 import com.example.demo.dto.user.response.UserProjectHistoryInfoResponseDto;
+import com.example.demo.dto.user.response.UserProjectHistoryPaginationResponseDto;
 import com.example.demo.model.project.Project;
 import com.example.demo.model.user.User;
 import com.example.demo.model.user.UserProjectHistory;
@@ -18,7 +19,7 @@ public interface UserProjectHistoryService {
     Long getUserProjectHistoryTotalCount(Long userId);
 
     // 회원 프로젝트 이력 조회
-    List<UserProjectHistoryInfoResponseDto> getUserProjectHistoryList(Long userId, int pageNumber);
+    UserProjectHistoryPaginationResponseDto getUserProjectHistoryList(Long userId, int pageNumber);
 
     // 회원 참여중인 프로젝트 이력 조회
     List<UserProjectHistory> getUserProjectHistoryListParticipates(Long userId, int pageIndex, int itemCount);

--- a/src/main/java/com/example/demo/service/user/UserProjectHistoryServiceImpl.java
+++ b/src/main/java/com/example/demo/service/user/UserProjectHistoryServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.demo.service.user;
 
 import com.example.demo.constant.UserProjectHistoryStatus;
 import com.example.demo.dto.user.response.UserProjectHistoryInfoResponseDto;
+import com.example.demo.dto.user.response.UserProjectHistoryPaginationResponseDto;
 import com.example.demo.model.project.Project;
 import com.example.demo.model.user.User;
 import com.example.demo.model.user.UserProjectHistory;
@@ -41,11 +42,10 @@ public class UserProjectHistoryServiceImpl implements UserProjectHistoryService 
     }
 
     @Override
-    public List<UserProjectHistoryInfoResponseDto> getUserProjectHistoryList(
+    public UserProjectHistoryPaginationResponseDto getUserProjectHistoryList(
             Long userId, int pageNumber) {
-        PageRequest pageRequest = PageRequest.of(pageNumber, 5);
         return userProjectHistoryRepository.findAllByUserIdOrderByUpdateDateDesc(
-                userId, pageRequest);
+                userId, PageRequest.of(pageNumber, 5));
     }
 
     @Override


### PR DESCRIPTION
### 작업내용
- 요구사항 변경으로 사용자 프로젝트 이력 목록 조회 시 페이징 처리된 프로젝트 이력 목록과 해당 사용자의 전체 프로젝트 이력 개수를 함께 조회하고 응답하도록 변경
```
    "data": {
        "content": [
            {
                "userProjectHistoryId": 73,
                "status": "PARTICIPATING",
                "projectName": "프로젝트 이름6",
                "updateDate": "2024-01-02"
            },
            {
                "userProjectHistoryId": 64,
                "status": "PARTICIPATING",
                "projectName": "프로젝트 이름5",
                "updateDate": "2024-01-02"
            },
            {
                "userProjectHistoryId": 55,
                "status": "PARTICIPATING",
                "projectName": "프로젝트 이름4",
                "updateDate": "2024-01-02"
            },
            {
                "userProjectHistoryId": 46,
                "status": "PARTICIPATING",
                "projectName": "프로젝트 이름3",
                "updateDate": "2024-01-02"
            },
            {
                "userProjectHistoryId": 37,
                "status": "PARTICIPATING",
                "projectName": "프로젝트 이름2",
                "updateDate": "2024-01-02"
            }
        ],
        "totalPages": 6
    }
```



### 연관이슈
close #314 