### PR TITLE
[feature/317-fix-project-member-works-with-trust-score] 프로젝트 멤버 업무 이력 및 업무 별 신뢰점수 내역 조회 응답 데이터 수정

### DIFF
--- a/src/main/java/com/example/demo/dto/projectmember/response/ProjectMemberWorkWithTrustScoreResponseDto.java
+++ b/src/main/java/com/example/demo/dto/projectmember/response/ProjectMemberWorkWithTrustScoreResponseDto.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 @Getter
 public class ProjectMemberWorkWithTrustScoreResponseDto {
 
+    private Long workId;
     private String workContent;
     private LocalDate startDate;
     private LocalDate endDate;
@@ -16,8 +17,9 @@ public class ProjectMemberWorkWithTrustScoreResponseDto {
     private Integer point;
     private String point_type;
 
-    public ProjectMemberWorkWithTrustScoreResponseDto(String workContent, LocalDate startDate,
+    public ProjectMemberWorkWithTrustScoreResponseDto(Long workId, String workContent, LocalDate startDate,
                                                       LocalDate endDate, ProgressStatus progressStatus, Integer point, String point_type) {
+        this.workId = workId;
         this.workContent = workContent;
         this.startDate = startDate;
         this.endDate = endDate;

--- a/src/main/java/com/example/demo/repository/work/WorkRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/work/WorkRepositoryImpl.java
@@ -78,6 +78,7 @@ public class WorkRepositoryImpl implements WorkRepositoryCustom{
                 .select(
                         Projections.constructor(
                                 ProjectMemberWorkWithTrustScoreResponseDto.class,
+                                qWork.id,
                                 qWork.content,
                                 qWork.startDate,
                                 qWork.endDate,


### PR DESCRIPTION
### 작업내용
- 요구사항 변경으로 프로젝트 멤버 업무 이력 및 업무 별 신뢰점수 내역을 조회하는 로직의 응답 데이터에 업무 ID(PK) 값 추가
```
    "data": {
        "content": [
            {
                "workId": 74,
                "workContent": "프로젝트12 > 마일스톤21 > 업무 내용8",
                "startDate": "2024-02-01",
                "endDate": "2024-02-10",
                "progressStatus": "진행중",
                "point": null,
                "point_type": null
            },
            {
                "workId": 28,
                "workContent": "프로젝트12 > 마일스톤21 > 업무 내용7",
                "startDate": "2024-01-18",
                "endDate": "2024-01-20",
                "progressStatus": "완료",
                "point": 20,
                "point_type": "minus"
            },
            {
                "workId": 27,
                "workContent": "프로젝트12 > 마일스톤21 > 업무 내용6",
                "startDate": "2024-01-13",
                "endDate": "2024-01-17",
                "progressStatus": "완료",
                "point": 50,
                "point_type": "plus"
            }
        ],
        "totalPages": 8
    }
```


### 연관이슈
close #317 