### PR TITLE
[feature/296-fix-alert-info-response] 알림 응답 정보 수정

### DIFF
--- a/src/main/java/com/example/demo/dto/alert/response/AlertInfoResponseDto.java
+++ b/src/main/java/com/example/demo/dto/alert/response/AlertInfoResponseDto.java
@@ -1,8 +1,10 @@
 package com.example.demo.dto.alert.response;
 
 import com.example.demo.constant.AlertType;
+import com.example.demo.dto.position.response.PositionInfoResponseDto;
 import com.example.demo.global.util.LocalDateTimeFormatSerializer;
 import com.example.demo.model.alert.Alert;
+import com.example.demo.model.position.Position;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -18,7 +20,7 @@ public class AlertInfoResponseDto {
     private Long sendUserId;
     private Long workId;
     private Long milestoneId;
-    private Long positionId;
+    private PositionInfoResponseDto position;
     private String content;
     private AlertType type;
 
@@ -28,7 +30,7 @@ public class AlertInfoResponseDto {
     @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime updateDate;
 
-    public static AlertInfoResponseDto of(Alert alert) {
+    public static AlertInfoResponseDto of(Alert alert, Position position) {
         return AlertInfoResponseDto.builder()
                 .alertId(alert.getId())
                 .projectId(alert.getProject().getId())
@@ -39,10 +41,10 @@ public class AlertInfoResponseDto {
                         ObjectUtils.isEmpty(alert.getMilestone())
                                 ? null
                                 : alert.getMilestone().getId())
-                .positionId(
-                        ObjectUtils.isEmpty(alert.getPosition())
+                .position(
+                        ObjectUtils.isEmpty(position)
                                 ? null
-                                : alert.getPosition().getId())
+                                : PositionInfoResponseDto.of(position.getId(), position.getName()))
                 .content(alert.getContent())
                 .type(alert.getType())
                 .createDate(alert.getCreateDate())

--- a/src/main/java/com/example/demo/service/alert/AlertFacade.java
+++ b/src/main/java/com/example/demo/service/alert/AlertFacade.java
@@ -64,7 +64,7 @@ public class AlertFacade {
         List<AlertInfoResponseDto> alertInfoResponseDtos = new ArrayList<>();
 
         for (Alert alert : alerts) {
-            alertInfoResponseDtos.add(AlertInfoResponseDto.of(alert));
+            alertInfoResponseDtos.add(AlertInfoResponseDto.of(alert, alert.getPosition()));
         }
 
         return alertInfoResponseDtos;
@@ -76,7 +76,7 @@ public class AlertFacade {
         List<AlertInfoResponseDto> alertInfoResponseDtos = new ArrayList<>();
 
         for (Alert alert : alerts) {
-            alertInfoResponseDtos.add(AlertInfoResponseDto.of(alert));
+            alertInfoResponseDtos.add(AlertInfoResponseDto.of(alert, alert.getPosition()));
         }
 
         return alertInfoResponseDtos;
@@ -88,7 +88,7 @@ public class AlertFacade {
         List<AlertInfoResponseDto> alertInfoResponseDtos = new ArrayList<>();
 
         for (Alert alert : alerts) {
-            alertInfoResponseDtos.add(AlertInfoResponseDto.of(alert));
+            alertInfoResponseDtos.add(AlertInfoResponseDto.of(alert, alert.getPosition()));
         }
 
         return alertInfoResponseDtos;
@@ -100,7 +100,7 @@ public class AlertFacade {
         List<AlertInfoResponseDto> alertInfoResponseDtos = new ArrayList<>();
 
         for (Alert alert : alerts) {
-            alertInfoResponseDtos.add(AlertInfoResponseDto.of(alert));
+            alertInfoResponseDtos.add(AlertInfoResponseDto.of(alert, alert.getPosition()));
         }
 
         return alertInfoResponseDtos;


### PR DESCRIPTION
### 작업내용
- 요구사항 변경으로 알림 정보 중 포지션 정보를 응답할 때 AlertInfoResponseDto에서 PositionInfoResponse 형태의 positionId, positionName으로 응답하도록 수정
- AlertInfoResponseDto의 of() 정적 메소드에서 알림 엔티티의 포지션 엔티티를 파라미터로 받도록 수정
- AlertInfoResponseDto의 of() 정적 메소드로 AlertInfoResponseDto를 응답하는 모든 로직에 position 매개변수 추가
```
   "data": [
        {
            "alertId": 1,
            "projectId": 12,
            "checkUserId": 1,
            "sendUserId": 1,
            "workId": null,
            "milestoneId": null,
            "position": {
                "positionId": 2,
                "positionName": "백엔드"
            },
            "content": "프로젝트 지원 테스트 알림",
            "type": "WORK",
            "createDate": "2024-01-05",
            "updateDate": "2024-01-05"
        }
    ]
```


### 연관이슈
close #296 