### PR TITLE
[feature/301-fix-work-read-response] 업무 조회 응답 데이터 수정

### DIFF
--- a/src/main/java/com/example/demo/dto/work/response/WorkAssignedUserInfoResponseDto.java
+++ b/src/main/java/com/example/demo/dto/work/response/WorkAssignedUserInfoResponseDto.java
@@ -1,0 +1,24 @@
+package com.example.demo.dto.work.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class WorkAssignedUserInfoResponseDto {
+
+    private Long projectMemberId;
+    private String nickname;
+
+    public WorkAssignedUserInfoResponseDto(Long projectMemberId, String nickname) {
+        this.projectMemberId = projectMemberId;
+        this.nickname = nickname;
+    }
+
+    public static WorkAssignedUserInfoResponseDto of(Long projectMemberId, String nickname) {
+        return WorkAssignedUserInfoResponseDto.builder()
+                .projectMemberId(projectMemberId)
+                .nickname(nickname)
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/dto/work/response/WorkReadResponseDto.java
+++ b/src/main/java/com/example/demo/dto/work/response/WorkReadResponseDto.java
@@ -1,6 +1,8 @@
 package com.example.demo.dto.work.response;
 
 import com.example.demo.constant.ProgressStatus;
+import com.example.demo.model.project.ProjectMember;
+import com.example.demo.model.user.User;
 import com.example.demo.model.work.Work;
 import java.time.LocalDate;
 
@@ -15,19 +17,19 @@ public class WorkReadResponseDto {
     private Long workId;
     private Long projectId;
     private Long milestoneId;
-    private String assignedUserNickname;
+    private WorkAssignedUserInfoResponseDto assignedUser;
     private String lastModifiedMemberNickname;
     private String content;
     private LocalDate startDate;
     private LocalDate endDate;
     private String progressStatus;
 
-    public WorkReadResponseDto(Long workId, Long projectId, Long milestoneId, String assignedUserNickname, String lastModifiedMemberNickname,
+    public WorkReadResponseDto(Long workId, Long projectId, Long milestoneId, WorkAssignedUserInfoResponseDto assignedUser, String lastModifiedMemberNickname,
                                String content, LocalDate startDate, LocalDate endDate, ProgressStatus progressStatus) {
         this.workId = workId;
         this.projectId = projectId;
         this.milestoneId = milestoneId;
-        this.assignedUserNickname = assignedUserNickname;
+        this.assignedUser = assignedUser;
         this.lastModifiedMemberNickname = lastModifiedMemberNickname;
         this.content = content;
         this.startDate = startDate;
@@ -35,12 +37,12 @@ public class WorkReadResponseDto {
         this.progressStatus = progressStatus.getDescription();
     }
 
-    public static WorkReadResponseDto of(Work work) {
+    public static WorkReadResponseDto of(Work work, ProjectMember projectMember, User assignedUser) {
         return WorkReadResponseDto.builder()
                 .workId(work.getId())
                 .projectId(work.getProject().getId())
                 .milestoneId(work.getMilestone().getId())
-                .assignedUserNickname(work.getAssignedUserId().getNickname())
+                .assignedUser(WorkAssignedUserInfoResponseDto.of(projectMember.getId(), assignedUser.getNickname()))
                 .lastModifiedMemberNickname(work.getLastModifiedMember().getUser().getNickname())
                 .content(work.getContent())
                 .startDate(work.getStartDate())

--- a/src/main/java/com/example/demo/service/work/WorkFacade.java
+++ b/src/main/java/com/example/demo/service/work/WorkFacade.java
@@ -53,7 +53,10 @@ public class WorkFacade {
 
         List<WorkReadResponseDto> workReadResponseDtos = new ArrayList<>();
         for (Work work : works) {
-            WorkReadResponseDto workReadResponseDto = WorkReadResponseDto.of(work);
+            User assignedUser = work.getAssignedUserId();
+            ProjectMember projectMember = projectMemberService.findProjectMemberByProjectAndUser(project, assignedUser);
+
+            WorkReadResponseDto workReadResponseDto = WorkReadResponseDto.of(work, projectMember, assignedUser);
             workReadResponseDtos.add(workReadResponseDto);
         }
 

--- a/src/main/java/com/example/demo/service/work/WorkServiceImpl.java
+++ b/src/main/java/com/example/demo/service/work/WorkServiceImpl.java
@@ -48,7 +48,7 @@ public class WorkServiceImpl implements WorkService {
 
     public WorkReadResponseDto getOne(Long workId) {
         Work work = findById(workId);
-        return WorkReadResponseDto.of(work);
+        return WorkReadResponseDto.of(work, null, null);
     }
 
     public void delete(Long workId) {


### PR DESCRIPTION
### 작업내용
- 프로젝트 멤버 ID(PK), 닉네임을 응답하는 WorkAssignedUserInfoResponseDto 생성
- 요구사항 변경으로 업무 조회 시 할당된 회원 정보를 WorkAssignedUserInfoResponseDto 형태로 응답하도록 수정
```
EX >
    "data": {
        "content": [
            {
                "workId": 28,
                "projectId": 12,
                "milestoneId": 21,
                "assignedUser": {
                    "projectMemberId": 19,
                    "nickname": "mmm123"
                },
                "lastModifiedMemberNickname": "mmm123",
                "content": "프로젝트12 > 마일스톤21 > 업무 내용7",
                "startDate": "2024-01-18",
                "endDate": "2024-01-20",
                "progressStatus": "완료"
            },
            {
                "workId": 74,
                "projectId": 12,
                "milestoneId": 21,
                "assignedUser": {
                    "projectMemberId": 19,
                    "nickname": "mmm123"
                },
                "lastModifiedMemberNickname": "mmm123",
                "content": "프로젝트12 > 마일스톤21 > 업무 내용8",
                "startDate": "2024-02-01",
                "endDate": "2024-02-10",
                "progressStatus": "진행중"
            },
            {
                "workId": 81,
                "projectId": 12,
                "milestoneId": 21,
                "assignedUser": {
                    "projectMemberId": 73,
                    "nickname": "zzz123"
                },
                "lastModifiedMemberNickname": "zzz123",
                "content": "프로젝트12 > 마일스톤21 > 업무 내용9",
                "startDate": "2024-02-01",
                "endDate": "2024-02-10",
                "progressStatus": "시작전"
            }
        ],
        "totalPages": 9
    }
```
- 업무 엔티티의 assignedUser(할당 회원) 정보는 회원 엔티티와 참조관계를 가지고 있어 프로젝트 멤버 ID(PK) 정보를 응답하기 위해 기존 WorkReadResponseDto를 응답하는 로직(프로젝트 > 마일스톤 >업무 목록 조회, 프로젝트의 업무 목록 조회, 하나의 업무 조회)에서 해당 회원의 ID(PK)와 업무가 속한 프로젝트의 ID(PK)로 프로젝트 멤버를 조회하고 ID(PK)를 응답하도록 로직 수정



### 연관이슈
close #301 