### PR TITLE
[feature/fix-work-get-one] 하나의 업무 조회 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/controller/work/WorkController.java
+++ b/src/main/java/com/example/demo/controller/work/WorkController.java
@@ -52,7 +52,7 @@ public class WorkController {
 
     @GetMapping("/api/work/{workId}")
     public ResponseEntity<ResponseDto<?>> getOne(@PathVariable("workId") Long workId) {
-        WorkReadResponseDto result = workService.getOne(workId);
+        WorkReadResponseDto result = workFacade.getOne(workId);
         return new ResponseEntity<>(ResponseDto.success("success", result), HttpStatus.OK);
     }
 

--- a/src/main/java/com/example/demo/service/work/WorkFacade.java
+++ b/src/main/java/com/example/demo/service/work/WorkFacade.java
@@ -46,9 +46,13 @@ public class WorkFacade {
         workService.save(work);
     }
 
+    @Transactional(readOnly = true)
     public WorkReadResponseDto getOne(Long workId) {
         Work work = workService.findById(workId);
-        return WorkReadResponseDto.of(work, null, null);
+        User assignedUser = work.getAssignedUserId();
+        ProjectMember projectMember = projectMemberService.findProjectMemberByProjectAndUser(work.getProject(), assignedUser);
+
+        return WorkReadResponseDto.of(work, projectMember, assignedUser);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/demo/service/work/WorkFacade.java
+++ b/src/main/java/com/example/demo/service/work/WorkFacade.java
@@ -46,6 +46,11 @@ public class WorkFacade {
         workService.save(work);
     }
 
+    public WorkReadResponseDto getOne(Long workId) {
+        Work work = workService.findById(workId);
+        return WorkReadResponseDto.of(work, null, null);
+    }
+
     @Transactional(readOnly = true)
     public List<WorkReadResponseDto> getAllByProject(Long projectId) {
         Project project = projectService.findById(projectId);

--- a/src/main/java/com/example/demo/service/work/WorkService.java
+++ b/src/main/java/com/example/demo/service/work/WorkService.java
@@ -24,8 +24,6 @@ public interface WorkService {
 
     public WorkPaginationResponseDto findWorksByProjectAndMilestone(Long projectId, Long milestoneId, Pageable pageable);
 
-    public WorkReadResponseDto getOne(Long workId);
-
     public void delete(Long workId);
 
     // 특정 프로젝트에 할당된 특정 회원의 업무 내역 + 업무 신뢰점수 내역 조회

--- a/src/main/java/com/example/demo/service/work/WorkServiceImpl.java
+++ b/src/main/java/com/example/demo/service/work/WorkServiceImpl.java
@@ -46,11 +46,6 @@ public class WorkServiceImpl implements WorkService {
                 .findWorkByProjectIdAndMilestoneIdOrderByStartDateAsc(projectId, milestoneId, pageable);
     }
 
-    public WorkReadResponseDto getOne(Long workId) {
-        Work work = findById(workId);
-        return WorkReadResponseDto.of(work, null, null);
-    }
-
     public void delete(Long workId) {
         Work work = findById(workId);
         workRepository.delete(work);


### PR DESCRIPTION
### 작업내용
- 하나의 업무 조회 시 응답하는 WorkReadResponseDto가 변경됨에 따라 해당 로직에서 프로젝트 멤버 엔티티를 조회하는 로직을 수행하기 위해 WorkService -> WorkFacade 클래스 이동 및 로직 수정 