### PR TITLE
[feature/322-fix-get-alerts-by-project] 프로젝트 내 알림 목록 조회 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/controller/alert/AlertController.java
+++ b/src/main/java/com/example/demo/controller/alert/AlertController.java
@@ -6,6 +6,8 @@ import com.example.demo.dto.common.ResponseDto;
 import com.example.demo.service.alert.AlertFacade;
 import com.example.demo.service.alert.AlertService;
 import java.util.List;
+import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,9 +29,10 @@ public class AlertController {
 
     @GetMapping("/api/alert/project/{projectId}")
     public ResponseEntity<ResponseDto<?>> getAllByProject(
-            @PathVariable("projectId") Long projectId) {
-        List<AlertInfoResponseDto> result = alertFacade.getAllByProject(projectId);
-        return new ResponseEntity<>(ResponseDto.success("success", result), HttpStatus.OK);
+            @PathVariable("projectId") Long projectId,
+            @RequestParam("pageIndex") Optional<Integer> pageIndex,
+            @RequestParam("itemCount") Optional<Integer> itemCount) {
+        return new ResponseEntity<>(ResponseDto.success("success", alertFacade.getAllByProject(projectId, pageIndex.orElse(0), itemCount.orElse(6))), HttpStatus.OK);
     }
 
     @GetMapping("/api/alert/project/{projectId}/recruits")

--- a/src/main/java/com/example/demo/dto/alert/response/AlertInfoResponseDto.java
+++ b/src/main/java/com/example/demo/dto/alert/response/AlertInfoResponseDto.java
@@ -7,6 +7,8 @@ import com.example.demo.model.alert.Alert;
 import com.example.demo.model.position.Position;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.time.LocalDateTime;
+import java.util.Objects;
+
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.util.ObjectUtils;
@@ -29,6 +31,22 @@ public class AlertInfoResponseDto {
 
     @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime updateDate;
+
+    public AlertInfoResponseDto(Long alertId, Long projectId, Long checkUserId, Long sendUserId,
+                                Long workId, Long milestoneId, PositionInfoResponseDto position,
+                                String content, AlertType type, LocalDateTime createDate, LocalDateTime updateDate) {
+        this.alertId = alertId;
+        this.projectId = projectId;
+        this.checkUserId = checkUserId;
+        this.sendUserId = sendUserId;
+        this.workId = Objects.nonNull(workId) ? workId : null;
+        this.milestoneId = Objects.nonNull(milestoneId) ? milestoneId : null;
+        this.position = Objects.nonNull(position.getPositionId()) ? position : null;
+        this.content = content;
+        this.type = type;
+        this.createDate = createDate;
+        this.updateDate = updateDate;
+    }
 
     public static AlertInfoResponseDto of(Alert alert, Position position) {
         return AlertInfoResponseDto.builder()

--- a/src/main/java/com/example/demo/dto/position/response/PositionInfoResponseDto.java
+++ b/src/main/java/com/example/demo/dto/position/response/PositionInfoResponseDto.java
@@ -11,6 +11,11 @@ public class PositionInfoResponseDto {
 
     private String positionName;
 
+    public PositionInfoResponseDto(Long positionId, String positionName) {
+        this.positionId = positionId;
+        this.positionName = positionName;
+    }
+
     public static PositionInfoResponseDto of(Long positionId, String positionName) {
         return PositionInfoResponseDto.builder()
                 .positionId(positionId)

--- a/src/main/java/com/example/demo/repository/alert/AlertRepository.java
+++ b/src/main/java/com/example/demo/repository/alert/AlertRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface AlertRepository extends JpaRepository<Alert, Long> {
+public interface AlertRepository extends JpaRepository<Alert, Long>, AlertRepositoryCustom {
 
     Optional<List<Alert>> findAlertsByProject(Project project);
 

--- a/src/main/java/com/example/demo/repository/alert/AlertRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/alert/AlertRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.example.demo.repository.alert;
+
+import com.example.demo.dto.alert.response.AlertInfoResponseDto;
+import com.example.demo.dto.common.PaginationResponseDto;
+import org.springframework.data.domain.Pageable;
+
+public interface AlertRepositoryCustom {
+
+    // 프로젝트 알람 목록 조회(페이징, 최신순 정렬)
+    PaginationResponseDto findAlertsByProjectIdOrderByCreateDateDesc(Long projectId, Pageable pageable);
+}

--- a/src/main/java/com/example/demo/repository/alert/AlertRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/alert/AlertRepositoryImpl.java
@@ -1,0 +1,83 @@
+package com.example.demo.repository.alert;
+
+import com.example.demo.dto.alert.response.AlertInfoResponseDto;
+import com.example.demo.dto.common.PaginationResponseDto;
+import com.example.demo.dto.position.response.PositionInfoResponseDto;
+import com.example.demo.model.alert.QAlert;
+import com.example.demo.model.milestone.QMilestone;
+import com.example.demo.model.position.QPosition;
+import com.example.demo.model.project.QProject;
+import com.example.demo.model.user.QUser;
+import com.example.demo.model.work.QWork;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class AlertRepositoryImpl implements AlertRepositoryCustom{
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QAlert qAlert = QAlert.alert;
+    private final QProject qProject = QProject.project;
+    private final QPosition qPosition = QPosition.position;
+    private final QUser qCheckUser = new QUser("checkUser");
+    private final QUser qSendUser = new QUser("sendUser");
+    private final QWork qWork = QWork.work;
+    private final QMilestone qMilestone = QMilestone.milestone;
+
+    @Override
+    public PaginationResponseDto findAlertsByProjectIdOrderByCreateDateDesc(Long projectId, Pageable pageable) {
+        List<AlertInfoResponseDto> content = jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                AlertInfoResponseDto.class,
+                                qAlert.id,
+                                qProject.id,
+                                qCheckUser.id,
+                                qSendUser.id,
+                                qWork.id,
+                                qMilestone.id,
+                                Projections.constructor(
+                                        PositionInfoResponseDto.class,
+                                        qPosition.id,
+                                        qPosition.name
+                                ),
+                                qAlert.content,
+                                qAlert.type,
+                                qAlert.createDate,
+                                qAlert.updateDate
+                        )
+                )
+                .from(qAlert)
+                .join(qAlert.project, qProject)
+                .leftJoin(qAlert.checkUser, qCheckUser)
+                .leftJoin(qAlert.sendUser, qSendUser)
+                .leftJoin(qAlert.work, qWork)
+                .leftJoin(qAlert.milestone, qMilestone)
+                .leftJoin(qAlert.position, qPosition)
+                .where(qProject.id.eq(projectId))
+                .orderBy(qAlert.createDate.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long totalPages = getAlertsTotalItemCount(projectId);
+
+        return PaginationResponseDto.of(content, totalPages);
+    }
+
+    // 알람 전체 개수 조회 (조건)
+    private long getAlertsTotalItemCount(Long projectId) {
+        return jpaQueryFactory
+                .select(qAlert.count())
+                .from(qAlert)
+                .join(qAlert.project, qProject)
+                .where(qAlert.project.id.eq(projectId))
+                .fetchOne();
+    }
+}

--- a/src/main/java/com/example/demo/service/alert/AlertFacade.java
+++ b/src/main/java/com/example/demo/service/alert/AlertFacade.java
@@ -2,6 +2,8 @@ package com.example.demo.service.alert;
 
 import com.example.demo.dto.alert.AlertCreateRequestDto;
 import com.example.demo.dto.alert.response.AlertInfoResponseDto;
+import com.example.demo.dto.common.PaginationResponseDto;
+import com.example.demo.global.exception.customexception.PageNationCustomException;
 import com.example.demo.model.alert.Alert;
 import com.example.demo.model.milestone.Milestone;
 import com.example.demo.model.position.Position;
@@ -58,16 +60,20 @@ public class AlertFacade {
         alertService.save(alert);
     }
 
-    public List<AlertInfoResponseDto> getAllByProject(Long projectId) {
+    public PaginationResponseDto getAllByProject(Long projectId, int pageIndex, int itemCount) {
         Project project = projectService.findById(projectId);
-        List<Alert> alerts = alertService.findAlertsByProjectId(project);
-        List<AlertInfoResponseDto> alertInfoResponseDtos = new ArrayList<>();
 
-        for (Alert alert : alerts) {
-            alertInfoResponseDtos.add(AlertInfoResponseDto.of(alert, alert.getPosition()));
+        if(pageIndex < 0) {
+            throw PageNationCustomException.INVALID_PAGE_NUMBER;
         }
 
-        return alertInfoResponseDtos;
+        if(itemCount < 0 || itemCount > 8) {
+            throw PageNationCustomException.INVALID_PAGE_ITEM_COUNT;
+        }
+
+        PaginationResponseDto alerts = alertService.findAlertsByProjectId(project, pageIndex, itemCount);
+
+        return alerts;
     }
 
     public List<AlertInfoResponseDto> getRecruitsByProject(Long projectId) {

--- a/src/main/java/com/example/demo/service/alert/AlertService.java
+++ b/src/main/java/com/example/demo/service/alert/AlertService.java
@@ -1,5 +1,7 @@
 package com.example.demo.service.alert;
 
+import com.example.demo.dto.alert.response.AlertInfoResponseDto;
+import com.example.demo.dto.common.PaginationResponseDto;
 import com.example.demo.model.alert.Alert;
 import com.example.demo.model.project.Project;
 import java.util.List;
@@ -12,7 +14,7 @@ public interface AlertService {
 
     public Alert save(Alert alert);
 
-    public List<Alert> findAlertsByProjectId(Project project);
+    public PaginationResponseDto findAlertsByProjectId(Project project, int pageIndex, int itemCount);
 
     public List<Alert> findRecruitAlertsByProject(Project project);
 

--- a/src/main/java/com/example/demo/service/alert/AlertServiceImpl.java
+++ b/src/main/java/com/example/demo/service/alert/AlertServiceImpl.java
@@ -1,11 +1,14 @@
 package com.example.demo.service.alert;
 
+import com.example.demo.dto.alert.response.AlertInfoResponseDto;
+import com.example.demo.dto.common.PaginationResponseDto;
 import com.example.demo.global.exception.customexception.AlertCustomException;
 import com.example.demo.model.alert.Alert;
 import com.example.demo.model.project.Project;
 import com.example.demo.repository.alert.AlertRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -23,10 +26,9 @@ public class AlertServiceImpl implements AlertService {
         return alertRepository.save(alert);
     }
 
-    public List<Alert> findAlertsByProjectId(Project project) {
+    public PaginationResponseDto findAlertsByProjectId(Project project, int pageIndex, int itemCount) {
         return alertRepository
-                .findAlertsByProject(project)
-                .orElseThrow(() -> AlertCustomException.NOT_FOUND_ALERT);
+                .findAlertsByProjectIdOrderByCreateDateDesc(project.getId(), PageRequest.of(pageIndex, itemCount));
     }
 
     public List<Alert> findRecruitAlertsByProject(Project project) {


### PR DESCRIPTION
### 작업내용
- 요구사항 변경으로 프로젝트 내 알림 목록 조회 요청에서 페이징 처리된 데이터 목록과 총 데이터 개수를 함께 응답하도록 로직 수정
- 요청한 프로젝트의 알림 목록을 createDate(생성날짜) 기준으로 최신순으로 정렬하고 클라이언트로부터 요청 받은 pageIndex(페이지 번호), itemCount(페이지에 보여줄 개수) 정보에 일치하는 데이터 목록을 응답하도록 수정 
- 총 4개의 데이터 중 pageIndex=0, itemCount=3 요청인 경우
```
    "data": {
        "content": [
            {
                "alertId": 5,
                "projectId": 1,
                "checkUserId": 1,
                "sendUserId": 21,
                "workId": null,
                "milestoneId": null,
                "position": null,
                "content": "프로젝트 1 지원합니다~",
                "type": "RECRUIT",
                "createDate": "2024-01-20",
                "updateDate": "2024-01-20"
            },
            {
                "alertId": 4,
                "projectId": 1,
                "checkUserId": 1,
                "sendUserId": 16,
                "workId": null,
                "milestoneId": null,
                "position": {
                    "positionId": 1,
                    "positionName": "프론트엔드"
                },
                "content": "프로젝트 1 지원!!",
                "type": "RECRUIT",
                "createDate": "2024-01-14",
                "updateDate": "2024-01-14"
            },
            {
                "alertId": 3,
                "projectId": 1,
                "checkUserId": 1,
                "sendUserId": 11,
                "workId": null,
                "milestoneId": null,
                "position": {
                    "positionId": 1,
                    "positionName": "프론트엔드"
                },
                "content": "프로젝트 1 지원",
                "type": "RECRUIT",
                "createDate": "2024-01-12",
                "updateDate": "2024-01-12"
            }
        ],
        "totalPages": 4
    }
```



### 연관이슈
close #322 