### PR TITLE
[feature/324-board-update-recruitment-status] 게시글 모집상태 변경 api 구현

### DIFF
--- a/src/main/java/com/example/demo/controller/board/BoardController.java
+++ b/src/main/java/com/example/demo/controller/board/BoardController.java
@@ -75,4 +75,11 @@ public class BoardController {
         boardFacade.deleteBoard(user.getId(), boardId);
         return new ResponseEntity<>(ResponseDto.success("success", null), HttpStatus.NO_CONTENT);
     }
+
+    @PatchMapping("/{boardId}/recruitment-status")
+    public ResponseEntity<ResponseDto<?>> updateBoardRecruitmentStatus(
+            @PathVariable Long boardId, @AuthenticationPrincipal PrincipalDetails user) {
+        boardService.updateRecruitmentStatus(boardId, user.getId());
+        return new ResponseEntity<>(ResponseDto.success("게시글 모집상태 변경이 완료되었습니다."), HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/example/demo/dto/board/Response/BoardCreateResponseDto.java
+++ b/src/main/java/com/example/demo/dto/board/Response/BoardCreateResponseDto.java
@@ -13,7 +13,7 @@ public class BoardCreateResponseDto {
     private String boardTitle;
     private String boardContent;
     private long boardPageView;
-    private boolean boardCompleteStatus;
+    private boolean recruitmentStatus;
     private long boardUserId;
     private String boardContact;
 
@@ -28,7 +28,7 @@ public class BoardCreateResponseDto {
                 .boardTitle(board.getTitle())
                 .boardContent(board.getContent())
                 .boardPageView(board.getPageView())
-                .boardCompleteStatus(board.isCompleteStatus())
+                .recruitmentStatus(board.isRecruitmentStatus())
                 .boardUserId(board.getUser().getId())
                 .boardContact(board.getContact())
                 .createDate(board.getCreateDate())

--- a/src/main/java/com/example/demo/dto/board/Response/BoardDetailResponseDto.java
+++ b/src/main/java/com/example/demo/dto/board/Response/BoardDetailResponseDto.java
@@ -17,7 +17,7 @@ public class BoardDetailResponseDto {
     private String title;
     private String content;
     private int pageView;
-    private boolean completeStatus;
+    private boolean recruitmentStatus;
     private UserBoardDetailResponseDto user;
     private String contact;
 
@@ -38,7 +38,7 @@ public class BoardDetailResponseDto {
                 .title(board.getTitle())
                 .content(board.getContent())
                 .pageView(board.getPageView())
-                .completeStatus(board.isCompleteStatus())
+                .recruitmentStatus(board.isRecruitmentStatus())
                 .user(userBoardDetailResponseDto)
                 .contact(board.getContact())
                 .createDate(board.getCreateDate())

--- a/src/main/java/com/example/demo/dto/board/Response/BoardSearchResponseDto.java
+++ b/src/main/java/com/example/demo/dto/board/Response/BoardSearchResponseDto.java
@@ -23,7 +23,7 @@ public class BoardSearchResponseDto {
     private LocalDateTime startDate;
     private LocalDateTime endDate;
     private int boardPageView;
-    private boolean boardCompleteStatus;
+    private boolean recruitmentStatus;
     private UserSearchResponseDto user;
     private String boardContact;
 
@@ -43,7 +43,7 @@ public class BoardSearchResponseDto {
             LocalDateTime startDate,
             LocalDateTime endDate,
             int boardPageView,
-            boolean boardCompleteStatus,
+            boolean recruitmentStatus,
             UserSearchResponseDto user,
             String boardContact,
             LocalDateTime createDate,
@@ -56,7 +56,7 @@ public class BoardSearchResponseDto {
         this.startDate = startDate;
         this.endDate = endDate;
         this.boardPageView = boardPageView;
-        this.boardCompleteStatus = boardCompleteStatus;
+        this.recruitmentStatus = recruitmentStatus;
         this.user = user;
         this.boardContact = boardContact;
         this.createDate = createDate;
@@ -75,7 +75,7 @@ public class BoardSearchResponseDto {
                 .boardPositions(boardPositions)
                 .project(boardProjectSearchResponseDto)
                 .boardPageView(board.getPageView())
-                .boardCompleteStatus(board.isCompleteStatus())
+                .recruitmentStatus(board.isRecruitmentStatus())
                 .user(userSearchResponseDto)
                 .boardContent(board.getContent())
                 .createDate(board.getCreateDate())

--- a/src/main/java/com/example/demo/dto/board/Response/BoardUpdateResponseDto.java
+++ b/src/main/java/com/example/demo/dto/board/Response/BoardUpdateResponseDto.java
@@ -14,7 +14,7 @@ public class BoardUpdateResponseDto {
     private String boardTitle;
     private String boardContent;
     private long boardPageView;
-    private boolean boardCompleteStatus;
+    private boolean recruitmentStatus;
     private long boardUserId;
     private String boardContact;
 
@@ -30,7 +30,7 @@ public class BoardUpdateResponseDto {
                 .boardTitle(board.getTitle())
                 .boardContent(board.getContent())
                 .boardPageView(board.getPageView())
-                .boardCompleteStatus(board.isCompleteStatus())
+                .recruitmentStatus(board.isRecruitmentStatus())
                 .boardUserId(board.getUser().getId())
                 .boardContact(board.getContent())
                 .createDate(board.getCreateDate())

--- a/src/main/java/com/example/demo/model/board/Board.java
+++ b/src/main/java/com/example/demo/model/board/Board.java
@@ -32,7 +32,7 @@ public class Board extends BaseTimeEntity {
     private int pageView;
 
     @ColumnDefault("false")
-    private boolean completeStatus;
+    private boolean recruitmentStatus;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -49,14 +49,14 @@ public class Board extends BaseTimeEntity {
             String content,
             Project project,
             int pageView,
-            boolean completeStatus,
+            boolean recruitmentStatus,
             User user,
             String contact) {
         this.title = title;
         this.content = content;
         this.project = project;
         this.pageView = pageView;
-        this.completeStatus = completeStatus;
+        this.recruitmentStatus = recruitmentStatus;
         this.user = user;
         this.contact = contact;
     }

--- a/src/main/java/com/example/demo/model/board/Board.java
+++ b/src/main/java/com/example/demo/model/board/Board.java
@@ -82,4 +82,8 @@ public class Board extends BaseTimeEntity {
     public void updatePageView() {
         this.pageView++;
     }
+
+    public void updateRecruitmentStatus(boolean completed) {
+        this.recruitmentStatus = completed;
+    }
 }

--- a/src/main/java/com/example/demo/service/board/BoardService.java
+++ b/src/main/java/com/example/demo/service/board/BoardService.java
@@ -21,4 +21,7 @@ public interface BoardService {
     public BoardTotalDetailResponseDto getDetail(Long boardId);
 
     public void delete(Board board);
+
+    @Transactional
+    void updateRecruitmentStatus(Long boardId, Long userId);
 }

--- a/src/main/java/com/example/demo/service/board/BoardServiceImpl.java
+++ b/src/main/java/com/example/demo/service/board/BoardServiceImpl.java
@@ -112,4 +112,29 @@ public class BoardServiceImpl implements BoardService {
     public void delete(Board board) {
         boardRepository.delete(board);
     }
+
+    /**
+     * 게시글 모집상태 변경, 모집중 -> 모집완료 or 모집완료 -> 모집중
+     * @param boardId
+     * @param userId
+     */
+    @Override
+    public void updateRecruitmentStatus(Long boardId, Long userId) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> BoardCustomException.NOT_FOUND_BOARD);
+
+        // 요청한 사용자와 게시글의 작성자가 다른 경우, 예외처리
+        if(!userId.equals(board.getUser().getId())) {
+            throw BoardCustomException.NO_PERMISSION_TO_EDIT_OR_DELETE;
+        }
+
+        // 게시글 모집상태가 모집중(false)인 경우, 모집완료(true)로 수정
+        if(!board.isRecruitmentStatus()) {
+            board.updateRecruitmentStatus(true);
+            return;
+        }
+
+        // 게시글 모집상태가 완료(true)인 경우, 모집중(false)으로 수정
+        board.updateRecruitmentStatus(false);
+    }
 }


### PR DESCRIPTION
### 작업내용
- 게시글의 모집상태를 모집중 -> 모집완료, 모집완료 -> 모집중으로 변경하는 로직 구현
- 요청한 사용자와 게시글을 작성한 사용자를 비교해 검증에 실패할 경우 게시글을 수정/삭제할 수 있는 권한이 존재하지 않는다는 예외를 처리하도록 구현



### 연관이슈
close #324 