### PR TITLE
[feature/331-add-user-profile-img] 회원 프로필 이미지 등록/변경 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ repositories {
 }
 
 dependencies {
+	/* aws cloud */
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 	/* jwt */
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/com/example/demo/controller/user/UserController.java
+++ b/src/main/java/com/example/demo/controller/user/UserController.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/user")
@@ -45,9 +46,10 @@ public class UserController {
     @PutMapping()
     public ResponseEntity<ResponseDto<?>> update(
             @AuthenticationPrincipal PrincipalDetails user,
-            @Valid @RequestBody UserUpdateRequestDto updateRequest) {
+            @RequestPart MultipartFile file,
+            @Valid @RequestPart UserUpdateRequestDto updateRequest) {
         return ResponseEntity.status(HttpStatus.OK)
-                .body(userFacade.updateUser(user, updateRequest));
+                .body(userFacade.updateUser(user, file, updateRequest));
     }
 
     // 간단한 내 정보 조회

--- a/src/main/java/com/example/demo/global/config/AwsS3Config.java
+++ b/src/main/java/com/example/demo/global/config/AwsS3Config.java
@@ -1,0 +1,32 @@
+package com.example.demo.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials basicAWSCredentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(basicAWSCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/demo/global/exception/GlobalExceptionHandler.java
@@ -4,11 +4,16 @@ import com.example.demo.dto.common.ResponseDto;
 import com.example.demo.global.exception.customexception.CustomException;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import com.example.demo.global.exception.customexception.FileCustomException;
+import com.example.demo.global.exception.errorcode.ErrorCode;
+import com.example.demo.global.exception.errorcode.FileErrorCode;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -26,6 +31,15 @@ public class GlobalExceptionHandler {
         final ResponseDto<List<CustomFieldError>> response =
                 ResponseDto.fail("데이터 유효성 검사에 실패했습니다.", errors);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    // 파일 크기 관련 Exception
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ResponseDto<?>> fileSizeError() {
+        ErrorCode errorCode = FileErrorCode.FILE_SIZE_EXCEEDED;
+
+        final ResponseDto response = ResponseDto.fail(errorCode.getMessage());
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
     }
 
     // CustomException

--- a/src/main/java/com/example/demo/global/exception/customexception/FileCustomException.java
+++ b/src/main/java/com/example/demo/global/exception/customexception/FileCustomException.java
@@ -1,0 +1,16 @@
+package com.example.demo.global.exception.customexception;
+
+import com.example.demo.global.exception.errorcode.FileErrorCode;
+
+public class FileCustomException extends CustomException{
+
+    public static final FileCustomException INVALID_IMAGE_TYPE =
+            new FileCustomException(FileErrorCode.INVALID_IMAGE_TYPE);
+
+    public static final FileCustomException FILE_SIZE_EXCEEDED =
+            new FileCustomException(FileErrorCode.FILE_SIZE_EXCEEDED);
+
+    public FileCustomException(FileErrorCode fileErrorCode) {
+        super(fileErrorCode);
+    }
+}

--- a/src/main/java/com/example/demo/global/exception/errorcode/FileErrorCode.java
+++ b/src/main/java/com/example/demo/global/exception/errorcode/FileErrorCode.java
@@ -1,0 +1,24 @@
+package com.example.demo.global.exception.errorcode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum FileErrorCode implements ErrorCode{
+    INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "올바르지 않은 이미지 타입(JPG, JPEG, PNG) 입니다."),
+    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기가 허용된 한도를 초과했습니다.");
+
+    private HttpStatus status;
+    private String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return this.status;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/example/demo/global/util/FileUtil.java
+++ b/src/main/java/com/example/demo/global/util/FileUtil.java
@@ -1,0 +1,56 @@
+package com.example.demo.global.util;
+
+import com.example.demo.global.exception.customexception.FileCustomException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Component
+public class FileUtil {
+
+    // MultipartFile 객체를 File 객체로 변환
+    public Optional<File> convert(MultipartFile file) throws IOException {
+        File convertFile = new File(file.getOriginalFilename());
+        if(convertFile.createNewFile()) {
+            try (FileOutputStream fos = new FileOutputStream(convertFile)) {
+                fos.write(file.getBytes());
+            }
+            return Optional.of(convertFile);
+        }
+        return Optional.empty();
+    }
+
+    // 새로운 파일명 생성 (랜덤 UUID + 원본 파일명)
+    public String makeNewFileName(String originFileName) {
+        String newFileName = UUID.randomUUID() + originFileName;
+        return newFileName;
+    }
+
+    // 임시 저장된 파일 삭제
+    public void removeNewFile(File file) {
+        if(file.delete()) {
+            log.info("Success File Remove.");
+            return;
+        }
+        log.info("Failed File Remove.");
+    }
+
+    // 이미지 파일 검증
+    public void validationImageType(MultipartFile multipartFile) {
+        String fileType = multipartFile.getContentType();
+
+        if(!fileType.equals(MediaType.IMAGE_JPEG_VALUE)
+            && !fileType.equals(MediaType.IMAGE_PNG_VALUE)
+            && !fileType.equals("image/jpg")) {
+            throw FileCustomException.INVALID_IMAGE_TYPE;
+        }
+    }
+}

--- a/src/main/java/com/example/demo/model/user/User.java
+++ b/src/main/java/com/example/demo/model/user/User.java
@@ -94,4 +94,9 @@ public class User extends BaseTimeEntity {
         this.position = position;
         this.intro = intro;
     }
+
+    // 회원 프로필 수정
+    public void updateProfileImgSrc(String profileImgSrc) {
+        this.profileImgSrc = profileImgSrc;
+    }
 }

--- a/src/main/java/com/example/demo/service/file/AwsS3FileService.java
+++ b/src/main/java/com/example/demo/service/file/AwsS3FileService.java
@@ -1,0 +1,59 @@
+package com.example.demo.service.file;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.example.demo.global.exception.customexception.CommonCustomException;
+import com.example.demo.global.util.FileUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AwsS3FileService {
+
+    private final AmazonS3Client amazonS3Client;
+    private final FileUtil fileUtil;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    // 클라이언트로부터 MultipartFile 타입의 이미지 파일을 전달받아 File 객체로 전환한 후 S3 업로드
+    public String uploadImage(MultipartFile file) throws IOException{
+        // 이미지 파일 검증
+        fileUtil.validationImageType(file);
+
+        // MultipartFile -> File 변환 및 새로운 파일명 생성
+        File uploadFile = fileUtil.convert(file)
+                .orElseThrow(() -> CommonCustomException.INTERNAL_SERVER_ERROR);
+
+        return upload(uploadFile);
+    }
+
+    private String upload(File uploadFile) {
+        String storedFileName = fileUtil.makeNewFileName(uploadFile.getName());
+        String uploadUrl = putS3(uploadFile, storedFileName);
+
+        // 로컬에 생성된 임시 File 객체 삭제
+        fileUtil.removeNewFile(uploadFile);
+
+        // 업로드된 파일의 S3 URL 반환
+        return uploadUrl;
+    }
+
+    // AWS S3 버킷에 파일 저장
+    private String putS3(File uploadFile, String fileName) {
+        amazonS3Client.putObject(
+                new PutObjectRequest(bucket, fileName, uploadFile)
+                        .withCannedAcl(CannedAccessControlList.PublicRead)
+        );
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,7 +15,7 @@ spring.datasource.password=${DATA_SOURCE_PASSWORD}
 spring.jpa.properties.hibernate.default_batch_fetch_size=1000
 
 #local  DB username
-#spring.datasource.url=jdbc:mysql://localhost:3308/projectMatch?createDatabaseIfNotExist=true&useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+#spring.datasource.url=jdbc:mysql://localhost:3306/projectMatch?createDatabaseIfNotExist=true&useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
 #spring.datasource.username=root
 #spring.datasource.password=password
 
@@ -49,12 +49,16 @@ jwt.refresh.token.expiration.millis=604800000
 #jwt.refresh.token.expiration.millis=12000
 
 # AWS S3
-#cloud.aws.s3.bucket=projectmatch-bucket
-#cloud.aws.region.static=ap-northeast-2
-#cloud.aws.regoin.auto=false
-#cloud.aws.stack.auto=false
-#cloud.aws.credentials.access-key=${S3_ACCESS_KEY}
-#cloud.aws.credentials.secret-key=${S3_SECRET_KEY}
+cloud.aws.s3.bucket=${S3-BUCKET_NAME}
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.regoin.auto=false
+cloud.aws.stack.auto=false
+cloud.aws.credentials.access-key=${S3_ACCESS_KEY}
+cloud.aws.credentials.secret-key=${S3_SECRET_KEY}
+
+# ?? ?? ??
+spring.servlet.multipart.max-file-size=5MB
+spring.servlet.multipart.max-request-size=5MB
 
 
 


### PR DESCRIPTION
### 작업내용
- 회원수정 로직에서 회원의 프로필 이미지도 함께 등록/변경할 수 있도록 수정, 회원수정 요청 시 파일 데이터를 요청받도록 수정
- 이미지 파일 저장을 위한 aws s3 버킷을 생성하고, 의존성을 추가해 생성한 aws s3 버킷과 연동
- application.properies에 aws s3 관련 설정 및 파일 관련 설정 추가 (파일의 최대 요청 가능한 크기를 5MB로 설정)
- 로컬환경에서 aws s3 접근 테스트를 위해 별도의 설정 필요(EC2에서 접근할 때는 필요없음)
```
1. 인텔리제이 Run(실행) 탭 클릭
2. 실행 탭에서 Edit Configurations(구성 편집) 탭 클릭
3. 구성 편집 창에서 VM Option에 "-Dcom.amazonaws.sdk.disableEc2Metadata=true" 추가
3-1. 만약 VM Option 칸이 존재하지 않는다면 Modify options(옵션 수정) 버튼 클릭 후, Add VM options(VM 옵션 추가) 클릭 후 위의 코드 추가
```

- 파일명 새로 구성, 로컬에 저장된 임시 파일 삭제, MultipartFile 타입을 File 타입으로 변환, 파일타입 검증 등 파일 관련 작업을 수행하는 FileUtil 클래스 추가
- aws s3 버킷에 실제 파일을 업로드, 다운로드, 조회, 삭제 역할을 담당하는 AwsS3FileService 추가 및 업로드 로직 구현
- 회원수정 시 요청한 파일 데이터가 있는 경우, 해당 파일을 업로드하고 회원의 프로필 이미지 경로를 수정하도록 로직 수정



### 연관이슈
#331 