### PR TITLE
[feature/331-my-profile-img-delete] 내 프로필 이미지 삭제 로직 구현

### DIFF
--- a/src/main/java/com/example/demo/controller/user/UserController.java
+++ b/src/main/java/com/example/demo/controller/user/UserController.java
@@ -73,4 +73,11 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(userFacade.getMyProjectHistoryList(user, pageNumber.orElse(0)));
     }
+
+    // 내 프로필 이미지 삭제
+    @DeleteMapping("/me/profile-img")
+    public ResponseEntity<ResponseDto<?>> myProfileImgDelete(@AuthenticationPrincipal PrincipalDetails user) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(userFacade.deleteMyProfileImg(user.getId()));
+    }
 }

--- a/src/main/java/com/example/demo/global/exception/customexception/UserCustomException.java
+++ b/src/main/java/com/example/demo/global/exception/customexception/UserCustomException.java
@@ -13,6 +13,9 @@ public class UserCustomException extends CustomException {
     public static final UserCustomException ALREADY_NICKNAME =
             new UserCustomException(UserErrorCode.ALREADY_NICKNAME);
 
+    public static final UserCustomException DOES_NOT_EXIST_PROFILE_IMG =
+            new UserCustomException(UserErrorCode.DOES_NOT_EXIST_PROFILE_IMG);
+
     public static final UserCustomException INVALID_AUTHENTICATION =
             new UserCustomException(UserErrorCode.INVALID_AUTHENTICATION);
 

--- a/src/main/java/com/example/demo/global/exception/errorcode/UserErrorCode.java
+++ b/src/main/java/com/example/demo/global/exception/errorcode/UserErrorCode.java
@@ -8,6 +8,7 @@ public enum UserErrorCode implements ErrorCode {
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "해당 유저가 존재하지 않습니다."),
     ALREADY_EMAIL(HttpStatus.CONFLICT, "이미 사용중인 이메일입니다."),
     ALREADY_NICKNAME(HttpStatus.CONFLICT, "이미 사용중인 닉네임입니다."),
+    DOES_NOT_EXIST_PROFILE_IMG(HttpStatus.NOT_FOUND, "요청한 회원의 프로필 이미지가 존재하지 않습니다."),
     INVALID_AUTHENTICATION(HttpStatus.BAD_REQUEST, "사용자 인증에 실패하였습니다. 이메일 혹은 비밀번호를 확인해주세요."),
     ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "요청한 URI에 접근할 권한이 존재하지 않습니다.");
 

--- a/src/main/java/com/example/demo/service/file/AwsS3FileService.java
+++ b/src/main/java/com/example/demo/service/file/AwsS3FileService.java
@@ -2,6 +2,7 @@ package com.example.demo.service.file;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.example.demo.global.exception.customexception.CommonCustomException;
 import com.example.demo.global.util.FileUtil;
@@ -55,5 +56,16 @@ public class AwsS3FileService {
                         .withCannedAcl(CannedAccessControlList.PublicRead)
         );
         return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    // 이미지 삭제
+    public void deleteImage(String fileName) {
+        String key = fileName.substring(fileName.lastIndexOf('/') + 1);
+        deleteS3(key);
+    }
+
+    // AWS S3 버킷에서 파일 삭제
+    private void deleteS3(String key) {
+        amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, key));
     }
 }


### PR DESCRIPTION
### 작업내용
- 요청한 회원의 프로필 이미지를 삭제하는 로직 구현
- 요청한 회원의 프로필 이미지가 존재하지 않는 경우 예외처리를 위해 DOES_NOT_EXIST_PROFILE_IMG 에러코드 및 커스텀 예외 추가
- 요청한 회원의 프로필 이미지가 존재하는 경우 aws s3 버킷에 저장된 이미지를 삭제하고 해당 회원 엔티티의 profileImgSrc 필드에 빈 값을 셋팅하도록 구현


### 연관이슈
#331 