### PR TITLE
[feature/fix-update-user-profile-img] 회원수정 로직에서 프로필 이미지 관련 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/service/user/UserFacade.java
+++ b/src/main/java/com/example/demo/service/user/UserFacade.java
@@ -127,7 +127,14 @@ public class UserFacade {
         User currentUser = userService.getUserForUpdate(user.getId());
 
         // 이미지 파일이 존재할 경우, 이미지 변경 수행
-        if(Objects.nonNull(file)) {
+        if(Objects.nonNull(file) && !file.isEmpty()) {
+            String profileImgSrc = currentUser.getProfileImgSrc();
+
+            // 기존 회원의 프로필 이미지가 존재할 경우 삭제
+            if(Objects.nonNull(profileImgSrc) && !profileImgSrc.isEmpty()) {
+                awsS3FileService.deleteImage(profileImgSrc);
+            }
+
             try {
                 currentUser.updateProfileImgSrc(awsS3FileService.uploadImage(file));
             } catch (IOException e) {


### PR DESCRIPTION
### 작업내용
- 파일 데이터를 요청하지 않아도 프로필 이미지 등록 조건을 실행하는 버그 수정
```
// 수정 전
if(Objects.nonNull(file)) {
    ....
}

// 수정 후
if(Objects.nonNull(file) && !file.isEmpty()) {
    ....
}
```
- 요청한 파일 데이터가 존재할 때, 프로필 이미지를 등록/변경 하기 전 이미 프로필 이미지가 존재하는 회원인 경우 기존 이미지 파일을 삭제하도록 로직 수정