### PR TITLE
[feature/fix-authentication-exception] 인증 예외처리 수정

### DIFF
--- a/src/main/java/com/example/demo/global/exception/customexception/AuthenticationCustomException.java
+++ b/src/main/java/com/example/demo/global/exception/customexception/AuthenticationCustomException.java
@@ -1,0 +1,14 @@
+package com.example.demo.global.exception.customexception;
+
+import com.example.demo.global.exception.errorcode.UserErrorCode;
+import org.springframework.security.core.AuthenticationException;
+
+public class AuthenticationCustomException extends AuthenticationException {
+
+    public static final AuthenticationCustomException INVALID_AUTHENTICATION =
+            new AuthenticationCustomException(UserErrorCode.INVALID_AUTHENTICATION.getMessage());
+
+    public AuthenticationCustomException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/example/demo/security/custom/PrincipalDetailsService.java
+++ b/src/main/java/com/example/demo/security/custom/PrincipalDetailsService.java
@@ -1,5 +1,7 @@
 package com.example.demo.security.custom;
 
+import com.example.demo.constant.UserStatus;
+import com.example.demo.global.exception.customexception.AuthenticationCustomException;
 import com.example.demo.global.exception.customexception.UserCustomException;
 import com.example.demo.model.user.User;
 import com.example.demo.repository.user.UserRepository;
@@ -22,7 +24,11 @@ public class PrincipalDetailsService implements UserDetailsService {
         User user =
                 userRepository
                         .findByEmail(username)
-                        .orElseThrow(() -> UserCustomException.INVALID_AUTHENTICATION);
+                        .orElse(null);
+
+        if(user == null || user.getStatus().equals(UserStatus.DELETED)) {
+            throw AuthenticationCustomException.INVALID_AUTHENTICATION;
+        }
 
         return new PrincipalDetails(user);
     }

--- a/src/main/java/com/example/demo/security/custom/UserAuthenticationFailureHandler.java
+++ b/src/main/java/com/example/demo/security/custom/UserAuthenticationFailureHandler.java
@@ -1,6 +1,7 @@
 package com.example.demo.security.custom;
 
 import com.example.demo.dto.common.ResponseDto;
+import com.example.demo.global.exception.customexception.AuthenticationCustomException;
 import com.example.demo.global.exception.errorcode.UserErrorCode;
 import com.example.demo.security.SecurityResponseHandler;
 import java.io.IOException;
@@ -8,6 +9,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 
@@ -19,9 +21,6 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationFa
 @RequiredArgsConstructor
 public class UserAuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
-    // 회원 인증 실패 시 응답 할 커스텀 ErrorCode
-    private static final UserErrorCode INVALID_AUTHENTICATION =
-            UserErrorCode.INVALID_AUTHENTICATION;
     private final SecurityResponseHandler securityResponseHandler;
 
     @Override
@@ -30,10 +29,12 @@ public class UserAuthenticationFailureHandler extends SimpleUrlAuthenticationFai
             HttpServletResponse response,
             AuthenticationException exception)
             throws IOException {
-        // 클라이언트로 응답 전송
-        securityResponseHandler.sendResponse(
-                response,
-                INVALID_AUTHENTICATION.getStatus(),
-                ResponseDto.fail(INVALID_AUTHENTICATION.getMessage()));
+        if(exception instanceof AuthenticationCustomException) {
+            // 클라이언트로 응답 전송
+            securityResponseHandler.sendResponse(
+                    response,
+                    HttpStatus.UNAUTHORIZED,
+                    ResponseDto.fail(exception.getMessage()));
+        }
     }
 }

--- a/src/main/java/com/example/demo/security/custom/UserAuthenticationFilter.java
+++ b/src/main/java/com/example/demo/security/custom/UserAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.example.demo.security.custom;
 
 import com.example.demo.dto.user.request.UserLoginRequestDto;
+import com.example.demo.global.exception.customexception.AuthenticationCustomException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
@@ -52,6 +53,10 @@ public class UserAuthenticationFilter extends AbstractAuthenticationProcessingFi
                         loginRequest.getEmail(), loginRequest.getPassword());
 
         // 회원 인증 로직 수행
-        return this.getAuthenticationManager().authenticate(token);
+        try {
+            return this.getAuthenticationManager().authenticate(token);
+        } catch(AuthenticationException e) {
+            throw AuthenticationCustomException.INVALID_AUTHENTICATION;
+        }
     }
 }


### PR DESCRIPTION
### 작업내용
```
org.springframework.security.authentication.InternalAuthenticationServiceException: null
	at org.springframework.security.authentication.dao.DaoAuthenticationProvider.retrieveUser(DaoAuthenticationProvider.java:109) ~[spring-security-core-5.7.11.jar:5.7.11]	
	.....
	.....
Caused by: com.example.demo.global.exception.customexception.UserCustomException: null
	at com.example.demo.global.exception.customexception.UserCustomException.<clinit>(UserCustomException.java:19) ~[main/:na]
	at com.example.demo.security.custom.PrincipalDetailsService.lambda$loadUserByUsername$0(PrincipalDetailsService.java:25) ~[main/:na]
	at java.base/java.util.Optional.orElseThrow(Optional.java:408) ~[na:na]
	at com.example.demo.security.custom.PrincipalDetailsService.loadUserByUsername(PrincipalDetailsService.java:25) ~[main/:na]
	at org.springframework.security.authentication.dao.DaoAuthenticationProvider.retrieveUser(DaoAuthenticationProvider.java:94) ~[spring-security-core-5.7.11.jar:5.7.11]
	... 62 common frames omitted
```
- 기존 로직에서 회원이 존재하지 않거나 요청한 이메일과 비밀번호가 일치하지 않는 경우 위와 같은 예외, 에러가 발생하는 문제 해결
- AuthenticationException을 상속 받는 AuthenticationCustomException을 생성해 인증 실패 시 처리할 예외 구현
- UserDetailsService를 상속한 PrincipalDetailsService의 loadUserByUsename() 메소드에서 회원이 존재하지 않거나 탈퇴한 회원인 경우, AuthenticationCustomException의 INVALID_AUTHENTICATION을 throw 하도록 수정
- UserAuthenticationFilter에서 실제 인증과정을 수행하는 authenticate() 메소드에서 AuthenticationException 발생 시, 커스텀한 AuthenticationCustomException을 throw 하도록 수정
- 인증실패 시 실행되는 UserAuthenticationFailureHandler에서 AuthenticationCustomException을 응답하도록 수정