### PR TITLE
[feature/331-user-withdraw] 회원 탈퇴 로직 구현

### DIFF
--- a/src/main/java/com/example/demo/controller/user/UserController.java
+++ b/src/main/java/com/example/demo/controller/user/UserController.java
@@ -80,4 +80,11 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(userFacade.deleteMyProfileImg(user.getId()));
     }
+
+    // 회원 탈퇴
+    @DeleteMapping()
+    public ResponseEntity<ResponseDto<?>> deleteUser(@AuthenticationPrincipal PrincipalDetails user) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(userFacade.deleteUser(user.getId()));
+    }
 }

--- a/src/main/java/com/example/demo/model/user/User.java
+++ b/src/main/java/com/example/demo/model/user/User.java
@@ -99,4 +99,9 @@ public class User extends BaseTimeEntity {
     public void updateProfileImgSrc(String profileImgSrc) {
         this.profileImgSrc = profileImgSrc;
     }
+
+    // 회원 삭제
+    public void deleteUser() {
+        this.status = UserStatus.DELETED;
+    }
 }

--- a/src/main/java/com/example/demo/service/user/UserFacade.java
+++ b/src/main/java/com/example/demo/service/user/UserFacade.java
@@ -353,4 +353,19 @@ public class UserFacade {
 
         return ResponseDto.success("프로필 이미지가 삭제되었습니다.");
     }
+
+    /**
+     * 회원 탈퇴
+     * @param userId
+     * @return
+     */
+    @Transactional
+    public ResponseDto<?> deleteUser(Long userId) {
+        User currentUser = userService.findById(userId);
+
+        // 회원 삭제(회원 엔티티의 status 필드에 UserStatus.DELETED 적용)
+        currentUser.deleteUser();
+
+        return ResponseDto.success("회원 탈퇴가 완료되었습니다.");
+    }
 }


### PR DESCRIPTION
### 작업내용
- 서비스 내 회원 탈퇴를 요청하는 로직 구현
- 회원 탈퇴 요청 시 로그인한 회원(요청한 회원)의 ID(PK) 값으로 회원 정보를 조회하고 해당 회원의 status 필드를 UserStatus.DELETED 값으로 변경하는 논리적 삭제 방법으로 구현 (추후 다양한 방법을 찾아 개선할 예정)



### 연관이슈
close #331 