### PR TITLE
[feature/fix-dockerfile] Dockerfile 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ ARG JAR_FILE=build/libs/demo-0.0.1-SNAPSHOT.jar
 COPY ${JAR_FILE} /app/projectmatch.jar
 
 # 애플리케이션 실행 (스프링 부트 JAR 실행)
-ENTRYPOINT ["java","-jar","/projectmatch.jar"]
+ENTRYPOINT ["java","-jar","/app/projectmatch.jar"]


### PR DESCRIPTION
### 작업내용
- 배포 시 ec2에서 애플리케이션 도커 컨테이너가 자동으로 실행되지 않는 버그 발생으로 빌드된 jar 파일을 /app 디렉토리에 복사했기 때문에 Dockerfile ENTRYPOINT의 jar 파일 경로에 /app 경로를 추가해 올바르게 참조하도록 수정