### PR TITLE
[feature/332-fix-project-participate-confirm] 프로젝트 참여지원 컨펌 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/controller/project/ProjectController.java
+++ b/src/main/java/com/example/demo/controller/project/ProjectController.java
@@ -64,12 +64,11 @@ public class ProjectController {
         return new ResponseEntity<>(ResponseDto.success("참여 요청이 완료되었습니다.", null), HttpStatus.OK);
     }
 
-    @PostMapping("/{projectId}/participate/confirm")
+    @PostMapping("/participate/confirm")
     public ResponseEntity<ResponseDto<?>> confirm(
             @AuthenticationPrincipal PrincipalDetails user,
-            @PathVariable("projectId") Long projectId,
-            @RequestBody @Valid ProjectConfirmRequestDto projectConfirmRequestDto) {
-        projectFacade.confirm(user.getId(), projectId, projectConfirmRequestDto);
+            @RequestBody ProjectConfirmRequestDto projectConfirmRequestDto) {
+        projectFacade.confirm(user.getId(), projectConfirmRequestDto);
         return new ResponseEntity<>(ResponseDto.success("success", null), HttpStatus.OK);
     }
 

--- a/src/main/java/com/example/demo/dto/project/request/ProjectConfirmRequestDto.java
+++ b/src/main/java/com/example/demo/dto/project/request/ProjectConfirmRequestDto.java
@@ -7,6 +7,10 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class ProjectConfirmRequestDto {
-    @NotNull(message = "포지션은 필수 입력 값입니다.")
-    private Long positionId;
+
+    @NotNull(message = "알림 정보는 필수 요청 값입니다.")
+    private Long alertId;
+
+    @NotNull(message = "참여 수락 혹은 거절 정보는 필수 요청 값입니다.")
+    private boolean confirmResult;
 }

--- a/src/main/java/com/example/demo/global/exception/customexception/ProjectCustomException.java
+++ b/src/main/java/com/example/demo/global/exception/customexception/ProjectCustomException.java
@@ -7,6 +7,9 @@ public class ProjectCustomException extends CustomException {
     public static final ProjectCustomException NOT_FOUND_PROJECT =
             new ProjectCustomException(ProjectErrorCode.NOT_FOUND_PROJECT);
 
+    public static final ProjectCustomException NO_PERMISSION_TO_TASK =
+            new ProjectCustomException(ProjectErrorCode.NO_PERMISSION_TO_TASK);
+
     public ProjectCustomException(ProjectErrorCode projectErrorCode) {
         super(projectErrorCode);
     }

--- a/src/main/java/com/example/demo/global/exception/errorcode/ProjectErrorCode.java
+++ b/src/main/java/com/example/demo/global/exception/errorcode/ProjectErrorCode.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
 public enum ProjectErrorCode implements ErrorCode {
-    NOT_FOUND_PROJECT(HttpStatus.NOT_FOUND, "해당 프로젝트가 존재하지 않습니다.");
+    NOT_FOUND_PROJECT(HttpStatus.NOT_FOUND, "해당 프로젝트가 존재하지 않습니다."),
+    NO_PERMISSION_TO_TASK(HttpStatus.FORBIDDEN, "해당 작업을 처리할 권한이 존재하지 않습니다.");
 
     private HttpStatus status;
     private String message;

--- a/src/main/java/com/example/demo/model/alert/Alert.java
+++ b/src/main/java/com/example/demo/model/alert/Alert.java
@@ -26,7 +26,7 @@ public class Alert extends BaseTimeEntity {
     private Project project;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "check_user_id", referencedColumnName = "user_id", nullable = false)
+    @JoinColumn(name = "check_user_id", referencedColumnName = "user_id")
     private User checkUser;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -53,6 +53,9 @@ public class Alert extends BaseTimeEntity {
     @Column(name = "checked_yn")
     private boolean checked_YN;
 
+    @Column(name = "project_participate_confirm")
+    private Boolean projectConfirmResult;
+
     @Builder
     private Alert(
             Project project,
@@ -63,7 +66,8 @@ public class Alert extends BaseTimeEntity {
             Position position,
             String content,
             AlertType type,
-            boolean checked_YN) {
+            boolean checked_YN,
+            Boolean projectConfirmResult) {
         this.project = project;
         this.checkUser = checkUser;
         this.sendUser = sendUser;
@@ -73,5 +77,10 @@ public class Alert extends BaseTimeEntity {
         this.content = content;
         this.type = type;
         this.checked_YN = checked_YN;
+        this.projectConfirmResult = projectConfirmResult;
+    }
+
+    public void updateProjectConfirmResult(boolean projectConfirmResult) {
+        this.projectConfirmResult = projectConfirmResult;
     }
 }


### PR DESCRIPTION
### 작업내용
- 기존 프로젝트 참여지원 수락 api를 수락 또는 거절로 다르게 처리되도록 로직 수정
- 프로젝트 참여 컨펌 api 요청 데이터 수정
```
{
    "alertId": Long,            # 해당 지원 알림의 ID(PK)
    "confirmResult": boolean    # 프로젝트 참여 컨펌 여부, 수락(true)/거절(false)
}
```
- api를 요청한 회원이 프로젝트 참여 컨펌을 수행할 수 있는지 검증하기 위한 에러코드 및 커스텀 예외 추가
- Alert 엔티티에 프로젝트 참여지원 시 컨펌 결과를 저장하기 위해 Boolean 타입의 project_participate_confirm 필드 추가
- Alert 엔티티에 프로젝트 참여지원 결과를 update 하기 위한 메소드 구현
- 프로젝트 참여 수락 시, 지원 알림 엔티티의 project_participate_confirm 필드를 true로 업데이트하고 새로운 프로젝트 합류 알림 생성
<img width="566" alt="스크린샷 2024-01-25 오후 5 47 45" src="https://github.com/oneMonthProject/Backend/assets/137881315/eee55831-1282-4d6c-aa0c-b40a26577ac5"><br>

- 프로젝트 참여 거절 시, 지원 알림 엔티티의 project_participate_confirm 필드를 false로 업데이트
- 프로젝트 합류 알림을 생성할 때 null 값을 셋팅하기 위해 Alert 엔티티의 check_user_id 필드의 nullable=false 속성 제거



### 연관이슈
#332 