### PR TITLE
[feature/350-supported-project-alerts-by-user] 사용자가 지원한 프로젝트 관련 알림목록 조회 로직 구현

### DIFF
--- a/src/main/java/com/example/demo/controller/alert/AlertController.java
+++ b/src/main/java/com/example/demo/controller/alert/AlertController.java
@@ -3,6 +3,7 @@ package com.example.demo.controller.alert;
 import com.example.demo.dto.alert.AlertCreateRequestDto;
 import com.example.demo.dto.alert.response.AlertInfoResponseDto;
 import com.example.demo.dto.common.ResponseDto;
+import com.example.demo.security.custom.PrincipalDetails;
 import com.example.demo.service.alert.AlertFacade;
 import com.example.demo.service.alert.AlertService;
 import java.util.List;
@@ -11,7 +12,10 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import javax.persistence.criteria.CriteriaBuilder;
 
 @RestController
 @RequiredArgsConstructor
@@ -60,5 +64,15 @@ public class AlertController {
     public ResponseEntity<ResponseDto<?>> updateAlertStatus(@PathVariable Long alertId) {
         alertService.updateAlertStatus(alertId);
         return new ResponseEntity<>(ResponseDto.success("success", null), HttpStatus.OK);
+    }
+
+    @GetMapping("/api/alert/supported-projects")
+    public ResponseEntity<ResponseDto<?>> getSupportedProjects(
+            @AuthenticationPrincipal PrincipalDetails user,
+            @RequestParam Optional<Integer> pageIndex,
+            @RequestParam Optional<Integer> itemCount) {
+        return new ResponseEntity<>(
+                ResponseDto.success("사용자가 지원한 프로젝트 알림목록 조회가 완료되었습니다.",
+                        alertFacade.getSupportedProjects(user.getId(), pageIndex.orElse(0), itemCount.orElse(6))), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/demo/dto/alert/response/AlertSupportedProjectInfoResponseDto.java
+++ b/src/main/java/com/example/demo/dto/alert/response/AlertSupportedProjectInfoResponseDto.java
@@ -1,0 +1,19 @@
+package com.example.demo.dto.alert.response;
+
+import com.example.demo.dto.position.response.PositionInfoResponseDto;
+import com.example.demo.dto.project.response.ProjectSimpleInfoResponseDto;
+import lombok.Getter;
+
+@Getter
+public class AlertSupportedProjectInfoResponseDto {
+
+    private ProjectSimpleInfoResponseDto project;
+    private PositionInfoResponseDto position;
+    private boolean supportResult;
+
+    public AlertSupportedProjectInfoResponseDto(ProjectSimpleInfoResponseDto project, PositionInfoResponseDto position, boolean supportResult) {
+        this.project = project;
+        this.position = position;
+        this.supportResult = supportResult;
+    }
+}

--- a/src/main/java/com/example/demo/dto/project/response/ProjectSimpleInfoResponseDto.java
+++ b/src/main/java/com/example/demo/dto/project/response/ProjectSimpleInfoResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.demo.dto.project.response;
+
+import lombok.Getter;
+
+@Getter
+public class ProjectSimpleInfoResponseDto {
+
+    private Long projectId;
+    private String projectName;
+
+    public ProjectSimpleInfoResponseDto(Long projectId, String projectName) {
+        this.projectId = projectId;
+        this.projectName = projectName;
+    }
+}

--- a/src/main/java/com/example/demo/repository/alert/AlertRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/alert/AlertRepositoryCustom.java
@@ -8,4 +8,7 @@ public interface AlertRepositoryCustom {
 
     // 프로젝트 알람 목록 조회(페이징, 최신순 정렬)
     PaginationResponseDto findAlertsByProjectIdOrderByCreateDateDesc(Long projectId, Pageable pageable);
+
+    // 사용자가 지원한 프로젝트 알람 목록 조회(페이징, 최신순 정렬)
+    PaginationResponseDto findAlertsBySendUserIdAndTypeOrderByCreateDateDesc(Long sendUserId, Pageable pageable);
 }

--- a/src/main/java/com/example/demo/repository/alert/AlertRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/alert/AlertRepositoryImpl.java
@@ -1,15 +1,20 @@
 package com.example.demo.repository.alert;
 
+import com.example.demo.constant.AlertType;
 import com.example.demo.dto.alert.response.AlertInfoResponseDto;
+import com.example.demo.dto.alert.response.AlertSupportedProjectInfoResponseDto;
 import com.example.demo.dto.common.PaginationResponseDto;
 import com.example.demo.dto.position.response.PositionInfoResponseDto;
+import com.example.demo.dto.project.response.ProjectSimpleInfoResponseDto;
 import com.example.demo.model.alert.QAlert;
 import com.example.demo.model.milestone.QMilestone;
 import com.example.demo.model.position.QPosition;
 import com.example.demo.model.project.QProject;
 import com.example.demo.model.user.QUser;
 import com.example.demo.model.work.QWork;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -66,18 +71,70 @@ public class AlertRepositoryImpl implements AlertRepositoryCustom{
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        long totalPages = getAlertsTotalItemCount(projectId);
+        long totalPages = getAlertsTotalItemCount(projectId, null, null);
+
+        return PaginationResponseDto.of(content, totalPages);
+    }
+
+    @Override
+    public PaginationResponseDto findAlertsBySendUserIdAndTypeOrderByCreateDateDesc(Long sendUserId, Pageable pageable) {
+        List<AlertSupportedProjectInfoResponseDto> content = jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                AlertSupportedProjectInfoResponseDto.class,
+                                Projections.constructor(
+                                        ProjectSimpleInfoResponseDto.class,
+                                        qProject.id,
+                                        qProject.name
+                                ),
+                                Projections.constructor(
+                                        PositionInfoResponseDto.class,
+                                        qPosition.id,
+                                        qPosition.name
+                                ),
+                                qAlert.projectConfirmResult
+                        )
+                )
+                .from(qAlert)
+                .join(qAlert.project, qProject)
+                .join(qAlert.position, qPosition)
+                .join(qAlert.sendUser, qSendUser)
+                .where(qSendUser.id.eq(sendUserId),
+                        qAlert.type.eq(AlertType.RECRUIT))
+                .orderBy(qAlert.createDate.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long totalPages = getAlertsTotalItemCount(null, sendUserId, AlertType.RECRUIT);
 
         return PaginationResponseDto.of(content, totalPages);
     }
 
     // 알람 전체 개수 조회 (조건)
-    private long getAlertsTotalItemCount(Long projectId) {
+    private long getAlertsTotalItemCount(Long projectId, Long sendUserId, AlertType alertType) {
         return jpaQueryFactory
                 .select(qAlert.count())
                 .from(qAlert)
-                .join(qAlert.project, qProject)
-                .where(qAlert.project.id.eq(projectId))
+                .where(eq(projectId, sendUserId, alertType))
                 .fetchOne();
+    }
+
+    private BooleanBuilder eq(Long projectId, Long sendUserId, AlertType alertType) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if(projectId != null) {
+            builder.and(qAlert.project.id.eq(projectId));
+        }
+
+        if(sendUserId != null) {
+            builder.and(qAlert.sendUser.id.eq(sendUserId));
+        }
+
+        if(alertType != null) {
+            builder.and(qAlert.type.eq(alertType));
+        }
+
+        return builder;
     }
 }

--- a/src/main/java/com/example/demo/service/alert/AlertFacade.java
+++ b/src/main/java/com/example/demo/service/alert/AlertFacade.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -110,5 +111,16 @@ public class AlertFacade {
         }
 
         return alertInfoResponseDtos;
+    }
+
+    @Transactional(readOnly = true)
+    public PaginationResponseDto getSupportedProjects(Long userId, int pageIndex, int itemCount) {
+        if(pageIndex < 0) {
+            throw PageNationCustomException.INVALID_PAGE_NUMBER;
+        }
+
+        User currentUser = userService.findById(userId);
+
+        return alertService.findAlertsBySendUserIdAndType(currentUser, pageIndex, itemCount);
     }
 }

--- a/src/main/java/com/example/demo/service/alert/AlertService.java
+++ b/src/main/java/com/example/demo/service/alert/AlertService.java
@@ -4,6 +4,8 @@ import com.example.demo.dto.common.PaginationResponseDto;
 import com.example.demo.model.alert.Alert;
 import com.example.demo.model.project.Project;
 import java.util.List;
+
+import com.example.demo.model.user.User;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -22,4 +24,6 @@ public interface AlertService {
     List<Alert> findCrewAlertsByProject(Project project);
 
     void updateAlertStatus(Long alertId);
+
+    PaginationResponseDto findAlertsBySendUserIdAndType(User user, int pageIndex, int itemCount);
 }

--- a/src/main/java/com/example/demo/service/alert/AlertServiceImpl.java
+++ b/src/main/java/com/example/demo/service/alert/AlertServiceImpl.java
@@ -5,6 +5,7 @@ import com.example.demo.dto.common.PaginationResponseDto;
 import com.example.demo.global.exception.customexception.AlertCustomException;
 import com.example.demo.model.alert.Alert;
 import com.example.demo.model.project.Project;
+import com.example.demo.model.user.User;
 import com.example.demo.repository.alert.AlertRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -52,5 +53,11 @@ public class AlertServiceImpl implements AlertService {
     @Override
     public void updateAlertStatus(Long alertId) {
         alertRepository.updateAlertStatus(alertId);
+    }
+
+    @Override
+    public PaginationResponseDto findAlertsBySendUserIdAndType(User user, int pageIndex, int itemCount) {
+        return alertRepository
+                .findAlertsBySendUserIdAndTypeOrderByCreateDateDesc(user.getId(), PageRequest.of(pageIndex, itemCount));
     }
 }


### PR DESCRIPTION
### 작업내용
- 사용자가 지원한 프로젝트에 대한 결과(수락/거절)를 확인하기 위한 알림목록 조회 로직 구현
- 프로젝트의 ID, Name 을 응답하는 ProjectSimpleInfoResponseDto 및 지원한 프로젝트 관련 알림 데이터를 응답하는 AlertSupportedProjectInfoResponseDto 생성
- 기존 전체 알림 데이터의 개수를 카운트하는 로직을 동적으로 처리하도록 변경 (BooleanBuilder로 상황에 맞는 쿼리가 동작하도록 수정)
- 조회한 결과 데이터 페이징 및 정렬 처리
- 예상 응답 값
```
    "data": {
        "content": [
            {
                "project": {
                    "projectId": 1,
                    "projectName": "프로젝트 이름 1"
                },
                "position": {
                    "positionId": 3,
                    "positionName": "안드로이드"
                },
                "supportResult": false
            },
            {
                "project": {
                    "projectId": 26,
                    "projectName": "프로젝트명 1"
                },
                "position": {
                    "positionId": 3,
                    "positionName": "안드로이드"
                },
                "supportResult": true
            },
            {
                "project": {
                    "projectId": 27,
                    "projectName": "trustcrew"
                },
                "position": {
                    "positionId": 3,
                    "positionName": "안드로이드"
                },
                "supportResult": false
            }
        ],
        "totalPages": 3
    }
```


### 연관이슈
close #350