### PR TITLE
feat: add projectId in UserProjectHistoryInfoResponseDto

### DIFF
--- a/src/main/java/com/example/demo/dto/user/response/UserProjectHistoryInfoResponseDto.java
+++ b/src/main/java/com/example/demo/dto/user/response/UserProjectHistoryInfoResponseDto.java
@@ -13,6 +13,8 @@ public class UserProjectHistoryInfoResponseDto {
 
     private Long userProjectHistoryId;
 
+    private Long projectId;
+
     private UserProjectHistoryStatus status;
 
     private String projectName;

--- a/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepositoryImpl.java
@@ -34,6 +34,7 @@ public class UserProjectHistoryRepositoryImpl implements UserProjectHistoryRepos
                                 Projections.constructor(
                                         UserProjectHistoryInfoResponseDto.class,
                                         userProjectHistory.id,
+                                        userProjectHistory.project.id,
                                         userProjectHistory.status,
                                         userProjectHistory.project.name,
                                         userProjectHistory.updateDate))


### PR DESCRIPTION
사용자 프로젝트 이력에서 해당 프로젝트를 클릭하면 그 프로젝트로 이동해야하는 부분이 있는데, 
여태 userProjectHistoryId 가 projectId 인 줄  알고  연결하고 있었습니다.. 
오류를 확인 하였는데 요청 드리기엔 제가 이번주 다음주에 시간이 별로 없어서 수정했습니다.

approve 해주시면 제가 merge 하겠습니다.