### PR TITLE
[feature/fix-user-participate-projects] 회원의 참여중인 프로젝트 이력 목록 조회 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.example.demo.repository.user;
 
 import java.util.List;
 
+import com.example.demo.constant.UserProjectHistoryStatus;
 import com.example.demo.dto.common.PaginationResponseDto;
 import com.example.demo.model.user.UserProjectHistory;
 import org.springframework.data.domain.Pageable;
@@ -12,12 +13,9 @@ public interface UserProjectHistoryRepositoryCustom {
     PaginationResponseDto findAllByUserIdOrderByUpdateDateDesc(
             Long userId, Pageable pageable);
 
-    // 회원 프로젝트 이력 전체 개수 조회
-    Long countUserProjectHistoryByUserId(Long userId);
-
-    // 회원 참여중인 프로젝트 이력 개수 조회
-    Long countParticipatesUserProjectHistoryByUserId(Long userId);
-
     // 회원 참여중인 프로젝트 이력 조회 (프로젝트 시작날짜 기준 오름차순 정렬, 페이징 offset 방법 활용)
     List<UserProjectHistory> findAllUserParticipates(Long userId, Pageable pageable);
+
+    // 회원 프로젝트 이력 개수 조회
+    Long countUserProjectHistory(Long userId, UserProjectHistoryStatus status);
 }

--- a/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepositoryImpl.java
@@ -7,10 +7,7 @@ import static com.example.demo.model.user.QUserProjectHistory.userProjectHistory
 import com.example.demo.constant.UserProjectHistoryStatus;
 import com.example.demo.dto.common.PaginationResponseDto;
 import com.example.demo.dto.user.response.UserProjectHistoryInfoResponseDto;
-import com.example.demo.model.project.QProjectMember;
-import com.example.demo.model.trust_grade.QTrustGrade;
 import com.example.demo.model.user.UserProjectHistory;
-import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -69,39 +66,22 @@ public class UserProjectHistoryRepositoryImpl implements UserProjectHistoryRepos
         return jpaQueryFactory
                 .select(userProjectHistory.count())
                 .from(userProjectHistory)
-                .where(getPredicateForUserAndUserProjectHistoryStatus(userId))
+                .where(userProjectHistory.user.id.eq(userId),
+                        userProjectHistory.status.eq(UserProjectHistoryStatus.PARTICIPATING))
                 .fetchOne();
     }
 
     @Override
     public List<UserProjectHistory> findAllUserParticipates(Long userId, Pageable pageable) {
-        QTrustGrade qTrustGrade = QTrustGrade.trustGrade;
-        QProjectMember qProjectMember = QProjectMember.projectMember;
-
         List<UserProjectHistory> results = jpaQueryFactory
                 .selectFrom(userProjectHistory)
-                .join(userProjectHistory.project, project)
-                .join(project.trustGrade, qTrustGrade)
-                .join(project.projectMembers, qProjectMember)
-                .join(qProjectMember.user, user)
-                .where(getPredicateForUserAndUserProjectHistoryStatus(userId))
+                .where(userProjectHistory.user.id.eq(userId),
+                        userProjectHistory.status.eq(UserProjectHistoryStatus.PARTICIPATING))
                 .orderBy(userProjectHistory.startDate.asc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
         return results;
-    }
-
-    private BooleanBuilder getPredicateForUserAndUserProjectHistoryStatus(Long userId) {
-        BooleanBuilder builder = new BooleanBuilder();
-
-        if(userId != null) {
-            builder.and(user.id.eq(userId));
-        }
-
-        builder.and(userProjectHistory.status.eq(UserProjectHistoryStatus.PARTICIPATING));
-
-        return builder;
     }
 }

--- a/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepositoryImpl.java
@@ -8,6 +8,7 @@ import com.example.demo.constant.UserProjectHistoryStatus;
 import com.example.demo.dto.common.PaginationResponseDto;
 import com.example.demo.dto.user.response.UserProjectHistoryInfoResponseDto;
 import com.example.demo.model.user.UserProjectHistory;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -44,31 +45,9 @@ public class UserProjectHistoryRepositoryImpl implements UserProjectHistoryRepos
                         .fetch();
 
         // 사용자 프로젝트 이력 총 개수 조회
-        long totalPages = countUserProjectHistoryByUserId(userId);
+        long totalPages = countUserProjectHistory(userId, null);
 
         return PaginationResponseDto.of(content, totalPages);
-    }
-
-    @Override
-    public Long countUserProjectHistoryByUserId(Long userId) {
-        // 회원의 전체 프로젝트 이력 개수 조회
-        return jpaQueryFactory
-                .select(userProjectHistory.count())
-                .from(userProjectHistory)
-                .leftJoin(userProjectHistory.user, user)
-                .where(userProjectHistory.user.id.eq(userId))
-                .fetchOne();
-    }
-
-    @Override
-    public Long countParticipatesUserProjectHistoryByUserId(Long userId) {
-        // 회원 참여중인 프로젝트 이력 개수 조회
-        return jpaQueryFactory
-                .select(userProjectHistory.count())
-                .from(userProjectHistory)
-                .where(userProjectHistory.user.id.eq(userId),
-                        userProjectHistory.status.eq(UserProjectHistoryStatus.PARTICIPATING))
-                .fetchOne();
     }
 
     @Override
@@ -83,5 +62,29 @@ public class UserProjectHistoryRepositoryImpl implements UserProjectHistoryRepos
                 .fetch();
 
         return results;
+    }
+
+    @Override
+    public Long countUserProjectHistory(Long userId, UserProjectHistoryStatus status) {
+        return jpaQueryFactory
+                .select(userProjectHistory.count())
+                .from(userProjectHistory)
+                .where(eq(userId, status))
+                .fetchOne();
+    }
+
+    // 갯수 조건 동적쿼리
+    private BooleanBuilder eq(Long userId, UserProjectHistoryStatus status) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if(userId != null) {
+            builder.and(userProjectHistory.user.id.eq(userId));
+        }
+
+        if(status != null) {
+            builder.and(userProjectHistory.status.eq(status));
+        }
+
+        return builder;
     }
 }

--- a/src/main/java/com/example/demo/service/project/ProjectFacade.java
+++ b/src/main/java/com/example/demo/service/project/ProjectFacade.java
@@ -2,6 +2,7 @@ package com.example.demo.service.project;
 
 import com.example.demo.constant.AlertType;
 import com.example.demo.constant.ProjectMemberStatus;
+import com.example.demo.constant.UserProjectHistoryStatus;
 import com.example.demo.dto.common.PaginationResponseDto;
 import com.example.demo.dto.project.request.ProjectConfirmRequestDto;
 import com.example.demo.dto.project.request.ProjectParticipateRequestDto;
@@ -63,7 +64,7 @@ public class ProjectFacade {
         }
 
         // 참여중인 프로젝트 개수 조회
-        long totalPages = userProjectHistoryService.getUserProjectHistoryParticipatesTotalCount(user.getId());
+        long totalPages = userProjectHistoryService.getUserProjectHistoryTotalCount(user.getId(), UserProjectHistoryStatus.PARTICIPATING);
 
         // 내가 참여중인 프로젝트 이력 목록 불러오기 (정렬, 페이징)
         List<UserProjectHistory> projectHistories = userProjectHistoryService.getUserProjectHistoryListParticipates(userId, pageIndex, itemCount);

--- a/src/main/java/com/example/demo/service/user/UserFacade.java
+++ b/src/main/java/com/example/demo/service/user/UserFacade.java
@@ -290,7 +290,7 @@ public class UserFacade {
                         .collect(Collectors.toList());
         // 회원 프로젝트 이력 개수
         long projectHistoryTotalCount =
-                userProjectHistoryService.getUserProjectHistoryTotalCount(currentUser.getId());
+                userProjectHistoryService.getUserProjectHistoryTotalCount(currentUser.getId(), null);
 
         // 내 정보 응답 DTO 생성
         UserMyInfoResponseDto myInfoResponse =

--- a/src/main/java/com/example/demo/service/user/UserProjectHistoryService.java
+++ b/src/main/java/com/example/demo/service/user/UserProjectHistoryService.java
@@ -1,5 +1,6 @@
 package com.example.demo.service.user;
 
+import com.example.demo.constant.UserProjectHistoryStatus;
 import com.example.demo.dto.common.PaginationResponseDto;
 import com.example.demo.model.project.Project;
 import com.example.demo.model.user.User;
@@ -15,14 +16,11 @@ public interface UserProjectHistoryService {
     public UserProjectHistory save(UserProjectHistory userProjectHistory);
 
     // 회원 프로젝트 이력 전체 개수 조회
-    Long getUserProjectHistoryTotalCount(Long userId);
+    Long getUserProjectHistoryTotalCount(Long userId, UserProjectHistoryStatus status);
 
     // 회원 프로젝트 이력 조회
     PaginationResponseDto getUserProjectHistoryList(Long userId, int pageNumber);
 
     // 회원 참여중인 프로젝트 이력 조회
     List<UserProjectHistory> getUserProjectHistoryListParticipates(Long userId, int pageIndex, int itemCount);
-
-    // 회원 참여중인 프로젝트 이력 개수 조회
-    Long getUserProjectHistoryParticipatesTotalCount(Long userId);
 }

--- a/src/main/java/com/example/demo/service/user/UserProjectHistoryServiceImpl.java
+++ b/src/main/java/com/example/demo/service/user/UserProjectHistoryServiceImpl.java
@@ -36,8 +36,8 @@ public class UserProjectHistoryServiceImpl implements UserProjectHistoryService 
     }
 
     @Override
-    public Long getUserProjectHistoryTotalCount(Long userId) {
-        return userProjectHistoryRepository.countUserProjectHistoryByUserId(userId);
+    public Long getUserProjectHistoryTotalCount(Long userId, UserProjectHistoryStatus status) {
+        return userProjectHistoryRepository.countUserProjectHistory(userId, status);
     }
 
     @Override
@@ -51,10 +51,5 @@ public class UserProjectHistoryServiceImpl implements UserProjectHistoryService 
     public List<UserProjectHistory> getUserProjectHistoryListParticipates(Long userId, int pageIndex, int itemCount) {
         Pageable pageable = PageRequest.of(pageIndex, itemCount);
         return userProjectHistoryRepository.findAllUserParticipates(userId, pageable);
-    }
-
-    @Override
-    public Long getUserProjectHistoryParticipatesTotalCount(Long userId) {
-        return userProjectHistoryRepository.countParticipatesUserProjectHistoryByUserId(userId);
     }
 }


### PR DESCRIPTION
### 작업내용
- 회원의 참여중인 프로젝트 이력 목록을 조회할 때 데이터가 중복되고 조건에 일치하는 데이터가 포함되지 않는 버그가 발생해 조회 쿼리 로직 수정
- 회원의 프로젝트 이력 목록 갯수를 조회하는 쿼리를 하나의 쿼리에서 조건에 따라 동적 쿼리로 처리되도록 변경