### PR TITLE
[feature/332-project-work-alert-confirm] 업무 컨펌 로직 구현

### DIFF
--- a/src/main/java/com/example/demo/controller/work/WorkController.java
+++ b/src/main/java/com/example/demo/controller/work/WorkController.java
@@ -10,8 +10,6 @@ import java.util.List;
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -93,5 +91,13 @@ public class WorkController {
             @RequestBody WorkUpdateAssignUserRequestDto workUpdateAssignUserRequestDto) {
         workFacade.updateAssignUser(workId, workUpdateAssignUserRequestDto);
         return new ResponseEntity<>(ResponseDto.success("success"), HttpStatus.OK);
+    }
+
+    @PostMapping("/api/work/confirm")
+    public ResponseEntity<ResponseDto<?>> workConfirm(
+            @AuthenticationPrincipal PrincipalDetails user,
+            @RequestBody WorkConfirmRequestDto workConfirmRequest) {
+        workFacade.workConfirm(user.getId(), workConfirmRequest);
+        return new ResponseEntity<>(ResponseDto.success("업무 컨펌이 완료되었습니다."), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/demo/dto/work/request/WorkConfirmRequestDto.java
+++ b/src/main/java/com/example/demo/dto/work/request/WorkConfirmRequestDto.java
@@ -1,0 +1,22 @@
+package com.example.demo.dto.work.request;
+
+import com.example.demo.constant.ProgressStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@AllArgsConstructor
+public class WorkConfirmRequestDto {
+
+    @NotBlank(message = "알림 정보는 필수 요청 값입니다.")
+    private Long alertId;
+
+    @NotBlank(message = "신뢰점수 부여(1) 혹은 차감(2)은 필수 요청 값입니다.")
+    private Long scoreTypeId;
+
+    public void updateScoreTypeId(Long scoreTypeId) {
+        this.scoreTypeId = scoreTypeId;
+    }
+}

--- a/src/main/java/com/example/demo/global/exception/customexception/WorkCustomException.java
+++ b/src/main/java/com/example/demo/global/exception/customexception/WorkCustomException.java
@@ -7,6 +7,9 @@ public class WorkCustomException extends CustomException {
     public static final WorkCustomException NOT_FOUND_WORK =
             new WorkCustomException(WorkErrorCode.NOT_FOUND_WORK);
 
+    public static final WorkCustomException NO_PERMISSION_TO_TASK =
+            new WorkCustomException(WorkErrorCode.NO_PERMISSION_TO_TASK);
+
     public WorkCustomException(WorkErrorCode workErrorCode) {
         super(workErrorCode);
     }

--- a/src/main/java/com/example/demo/global/exception/errorcode/WorkErrorCode.java
+++ b/src/main/java/com/example/demo/global/exception/errorcode/WorkErrorCode.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
 public enum WorkErrorCode implements ErrorCode {
-    NOT_FOUND_WORK(HttpStatus.NOT_FOUND, "해당 작업이 존재하지 않습니다.");
+    NOT_FOUND_WORK(HttpStatus.NOT_FOUND, "해당 작업이 존재하지 않습니다."),
+    NO_PERMISSION_TO_TASK(HttpStatus.FORBIDDEN, "해당 작업을 처리할 권한이 존재하지 않습니다.");
 
     private HttpStatus status;
     private String message;

--- a/src/main/java/com/example/demo/global/validation/validator/AddPointDtoValidator.java
+++ b/src/main/java/com/example/demo/global/validation/validator/AddPointDtoValidator.java
@@ -258,7 +258,7 @@ public class AddPointDtoValidator implements ConstraintValidator<ValidAddPointDt
                         .findById(workId)
                         .orElseThrow(() -> WorkCustomException.NOT_FOUND_WORK);
 
-        if (!work.getProgressStatus().equals(ProgressStatus.COMPLETION)) {
+        if (work.getProgressStatus().equals(ProgressStatus.BEFORE_START) || work.getProgressStatus().equals(ProgressStatus.ON_GOING)) {
             log.info("데이터 무결성 위배. 업무 미완성. workId : {}", workId);
             return false;
         }


### PR DESCRIPTION
### 작업내용
- 업무 완료 및 기간만료 시 해당 업무에 대한 신뢰점수를 부여/차감 처리를 수행하는 컨펌 로직 구현
- 업무 완료 및 기간만료 시 발송되는 업무 관련 알림 정보와 scoreTypeId(부여/차감) 정보로 해당 업무가 포함된 프로젝트의 등급과 scoreTypeId 정보에 따라 각각의 신뢰점수를 부여 및 차감하도록 구현
```
{
    "alertId": Long,
    "scoreTypeId": Long(1 or 2)
}
```
<br>

- 요청한 사용자가 업무 컨펌 작업을 수행할 수 있는 사용자인지 검증하는 로직과 에러코드 및 커스텀 예외 추가
- 기존 신뢰점수 부여 및 차감 로직에서 사용하는 AddPointDto를 검증하는 aop에서 업무 관련 검증 조건 수정, 업무의 미완수 조건을 progress_status가 'COMPLETION' 혹은 'EXPIRED'가 아닌 경우로 수정
<br><br><br>


### 연관이슈
close #332 