### PR TITLE
[feature/361-fix-projectmembers-by-project] 프로젝트 멤버 목록 조회 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/service/project/ProjectMemberFacade.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberFacade.java
@@ -122,7 +122,7 @@ public class ProjectMemberFacade {
                             userReadProjectCrewResponseDto,
                             projectMemberAuthResponseDto,
                             positionResponseDto,
-                            lastCompleteWork.getCompleteDate());
+                            lastCompleteWork != null ? lastCompleteWork.getCompleteDate() : null);
             projectMemberReadProjectCrewsResponseDtos.add(projectMemberReadProjectCrewsResponseDto);
         }
 

--- a/src/main/java/com/example/demo/service/work/WorkServiceImpl.java
+++ b/src/main/java/com/example/demo/service/work/WorkServiceImpl.java
@@ -36,7 +36,7 @@ public class WorkServiceImpl implements WorkService {
         return workRepository
                 .findFirstByProjectAndAssignedUserIdAndProgressStatusOrderByIdDesc(
                         project, user, ProgressStatus.COMPLETION)
-                .orElseThrow(() -> WorkCustomException.NOT_FOUND_WORK);
+                .orElse(null);
     }
 
     public PaginationResponseDto findWorksByProjectAndMilestone(Long projectId, Long milestoneId, Pageable pageable) {


### PR DESCRIPTION
### 작업내용
- 기존 프로젝트의 멤버 목록을 조회하는 로직에서 각 멤버의 마지막에 완료한 작업 정보가 없는 경우 orElseThrow()로 예외를 처리하여 제대로된 정보를 응답하지 못하는 이슈 해결
- 해당 멤버가 마지막에 완료한 작업이 없는 경우 예외를 처리하지 않고 orElse(null)로 null을 반환하고 DTO의 값을 셋팅할 때 null인 경우 null 값을 응답하도록 수정
- 업무가 없는 경우
`"lastWorkDate": null`
- 업무가 존재하는 경우
`"lastWorkDate": "2024-01-30"`
<br><br><br>
### 연관이슈
close #361 