### PR TITLE
[feature/360-verified-project-manager] 프로젝트 매니저 검증 로직 구현

### DIFF
--- a/src/main/java/com/example/demo/constant/ProjectRole.java
+++ b/src/main/java/com/example/demo/constant/ProjectRole.java
@@ -1,0 +1,30 @@
+package com.example.demo.constant;
+
+import com.example.demo.global.exception.customexception.ProjectMemberAuthCustomException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+@AllArgsConstructor
+public enum ProjectRole {
+
+    MANAGER(1L, "매니저"),
+    SUB_MANAGER(2L, "부매니저"),
+    MEMBER(3L, "구성원");
+
+    private Long id;
+    private String name;
+
+    public boolean isManager() {
+        return this.equals(MANAGER);
+    }
+
+    public static ProjectRole findProjectRole(Long roleId) {
+        return Arrays.stream(ProjectRole.values())
+                .filter(role -> role.id.equals(roleId))
+                .findFirst()
+                .orElseThrow(() -> ProjectMemberAuthCustomException.NOT_FOUND_PROJECT_MEMBER_AUTH);
+    }
+}

--- a/src/main/java/com/example/demo/global/exception/customexception/ProjectMemberAuthCustomException.java
+++ b/src/main/java/com/example/demo/global/exception/customexception/ProjectMemberAuthCustomException.java
@@ -8,6 +8,9 @@ public class ProjectMemberAuthCustomException extends CustomException {
             new ProjectMemberAuthCustomException(
                     ProjectMemberAuthErrorCode.NOT_FOUND_PROJECT_MEMBER_AUTH);
 
+    public static final ProjectMemberAuthCustomException INSUFFICIENT_PROJECT_AUTH =
+            new ProjectMemberAuthCustomException(ProjectMemberAuthErrorCode.INSUFFICIENT_PROJECT_AUTH);
+
     public ProjectMemberAuthCustomException(ProjectMemberAuthErrorCode projectMemberAuthErrorCode) {
         super(projectMemberAuthErrorCode);
     }

--- a/src/main/java/com/example/demo/global/exception/errorcode/ProjectMemberAuthErrorCode.java
+++ b/src/main/java/com/example/demo/global/exception/errorcode/ProjectMemberAuthErrorCode.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
 public enum ProjectMemberAuthErrorCode implements ErrorCode {
-    NOT_FOUND_PROJECT_MEMBER_AUTH(HttpStatus.NOT_FOUND, "해당 프로젝트 멤버 권한이 존재하지 않습니다.");
+    NOT_FOUND_PROJECT_MEMBER_AUTH(HttpStatus.NOT_FOUND, "해당 프로젝트 멤버 권한이 존재하지 않습니다."),
+    INSUFFICIENT_PROJECT_AUTH(HttpStatus.FORBIDDEN, "해당 작업을 처리할 프로젝트 권한이 부족합니다.");
 
     private HttpStatus status;
     private String message;

--- a/src/main/java/com/example/demo/service/project/ProjectMemberService.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberService.java
@@ -33,4 +33,6 @@ public interface ProjectMemberService {
     public ProjectMember findProjectMemberByProjectAndUser(Project project, User user);
 
     Map<String, Boolean> getUserAuthMap(Long projectId, Long userId);
+
+    void verifiedProjectManager(Project project, User user);
 }

--- a/src/main/java/com/example/demo/service/project/ProjectMemberServiceImpl.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberServiceImpl.java
@@ -1,6 +1,8 @@
 package com.example.demo.service.project;
 
 import com.example.demo.constant.ProjectMemberStatus;
+import com.example.demo.constant.ProjectRole;
+import com.example.demo.global.exception.customexception.ProjectMemberAuthCustomException;
 import com.example.demo.global.exception.customexception.ProjectMemberCustomException;
 import com.example.demo.model.position.Position;
 import com.example.demo.model.project.Project;
@@ -92,6 +94,19 @@ public class ProjectMemberServiceImpl implements ProjectMemberService {
     @Override
     public Map<String, Boolean> getUserAuthMap(Long projectId, Long userId) {
         return getAuthMap(getProjectMemberAuth(projectId, userId));
+    }
+
+    @Override
+    public void verifiedProjectManager(Project project, User user) {
+        ProjectMember member = projectMemberRepository
+                .findProjectMemberByProjectAndUser(project, user)
+                .orElseThrow(() -> ProjectMemberCustomException.NOT_FOUND_PROJECT_MEMBER);
+
+        // 프로젝트 매니저 확인
+        ProjectRole projectRole = ProjectRole.findProjectRole(member.getProjectMemberAuth().getId());
+        if(!projectRole.isManager()) {
+            throw ProjectMemberAuthCustomException.INSUFFICIENT_PROJECT_AUTH;
+        }
     }
 
     private static Map<String, Boolean> getAuthMap(ProjectMemberAuth projectMemberAuth) {

--- a/src/main/java/com/example/demo/service/work/WorkFacade.java
+++ b/src/main/java/com/example/demo/service/work/WorkFacade.java
@@ -165,14 +165,12 @@ public class WorkFacade {
     public void workConfirm(Long userId, WorkConfirmRequestDto workConfirmRequest) {
         User currentUser = userService.findById(userId);
         Alert alert = alertService.findById(workConfirmRequest.getAlertId());
+        Project project = alert.getProject();
 
-        // 업무을 컨펌할 수 있는 회원인지 검증
-        if(!currentUser.getId().equals(alert.getCheckUser().getId())) {
-            throw WorkCustomException.NO_PERMISSION_TO_TASK;
-        }
+        // 프로젝트 매니저 확인
+        projectMemberService.verifiedProjectManager(project, currentUser);
 
         Work work = alert.getWork();
-
         // 업무가 기간만료된 상태라면
         if(work.getProgressStatus().equals(ProgressStatus.EXPIRED)) {
             workConfirmRequest.updateScoreTypeId(22L);
@@ -181,7 +179,7 @@ public class WorkFacade {
         // 신뢰점수 부여 DTO
         AddPointDto addPoint = AddPointDto.builder()
                 .userId(alert.getSendUser().getId())
-                .projectId(alert.getProject().getId())
+                .projectId(project.getId())
                 .milestoneId(alert.getMilestone().getId())
                 .workId(work.getId())
                 .scoreTypeId(workConfirmRequest.getScoreTypeId())


### PR DESCRIPTION
### 작업내용
- 프로젝트 역할, 권한이 매니저인지 검증하는 로직 구현
- 요청한 사용자의 해당 프로젝트 역할, 권한을 비교 및 검증하기 위한 ProjectRole enum 파일 생성
- 프로젝트 매니저 검증 로직에서 매니저가 아닐 경우, `INSUFFICIENT_PROJECT_AUTH(HttpStatus.FORBIDDEN, "해당 작업을 처리할 프로젝트 권한이 부족합니다.")` 커스텀 예외를 처리하도록 구현
- 기존 프로젝트 참여 지원 컨펌 로직과 업무 컨펌로직에 프로젝트 매니저 검증 로직 추가, 추후 탈퇴 컨펌 로직에도 수정 후 추가 예정
<br><br><br>
### 연관이슈
close #360 