### PR TITLE
[feature/fix-project-withdraw-confirm] 프로젝트 탈퇴 컨펌 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/controller/project/ProjectMemberController.java
+++ b/src/main/java/com/example/demo/controller/project/ProjectMemberController.java
@@ -1,13 +1,16 @@
 package com.example.demo.controller.project;
 
 import com.example.demo.dto.common.ResponseDto;
+import com.example.demo.dto.project.request.ProjectWithdrawConfirmRequestDto;
 import com.example.demo.dto.projectmember.response.ProjectMemberReadCrewDetailResponseDto;
 import com.example.demo.dto.projectmember.response.ProjectMemberReadTotalProjectCrewsResponseDto;
+import com.example.demo.security.custom.PrincipalDetails;
 import com.example.demo.service.project.ProjectMemberFacade;
 import com.example.demo.service.project.ProjectMemberService;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Optional;
@@ -20,17 +23,18 @@ public class ProjectMemberController {
     private final ProjectMemberService projectMemberService;
     private final ProjectMemberFacade projectMemberFacade;
 
-    @PostMapping("/{projectMemberId}/withdrawl")
-    public ResponseEntity<ResponseDto<?>> withdrawl(
+    @PostMapping("/{projectMemberId}/withdraw")
+    public ResponseEntity<ResponseDto<?>> withdraw(
             @PathVariable("projectMemberId") Long projectMemberId) {
         projectMemberFacade.sendWithdrawlAlert(projectMemberId);
         return new ResponseEntity<>(ResponseDto.success("success"), HttpStatus.OK);
     }
 
-    @PostMapping("/{projectMemberId}/withdrawl/confirm")
-    public ResponseEntity<ResponseDto<?>> withdrawlConfirm(
-            @PathVariable("projectMemberId") Long projectMemberId) {
-        projectMemberService.withdrawlConfirm(projectMemberId);
+    @PostMapping("/withdraw/confirm")
+    public ResponseEntity<ResponseDto<?>> withdrawConfirm(
+            @AuthenticationPrincipal PrincipalDetails user,
+            @RequestBody ProjectWithdrawConfirmRequestDto withdrawConfirmRequest) {
+        projectMemberFacade.withdrawConfirm(user.getId(), withdrawConfirmRequest);
         return new ResponseEntity<>(ResponseDto.success("success"), HttpStatus.OK);
     }
 

--- a/src/main/java/com/example/demo/dto/project/request/ProjectWithdrawConfirmRequestDto.java
+++ b/src/main/java/com/example/demo/dto/project/request/ProjectWithdrawConfirmRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.demo.dto.project.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@AllArgsConstructor
+public class ProjectWithdrawConfirmRequestDto {
+
+    @NotBlank(message = "탈퇴신청 알림 정보는 필수 요청 값입니다.")
+    private Long alertId;
+
+    @NotBlank(message = "탈퇴 컨펌 정보는 필수 요청 값입니다.")
+    private boolean withdrawConfirm;
+}

--- a/src/main/java/com/example/demo/service/project/ProjectMemberService.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberService.java
@@ -24,9 +24,9 @@ public interface ProjectMemberService {
 
     public ProjectMember save(ProjectMember projectMember);
 
-    public List<ProjectMember> findProjectsMemberByProject(Project project);
+    void delete(ProjectMember projectMember);
 
-    public void withdrawlConfirm(Long projectMemberId);
+    public List<ProjectMember> findProjectsMemberByProject(Project project);
 
     public void withdrawlForce(Long projectMemberId);
 

--- a/src/main/java/com/example/demo/service/project/ProjectMemberServiceImpl.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberServiceImpl.java
@@ -64,13 +64,8 @@ public class ProjectMemberServiceImpl implements ProjectMemberService {
         return projectMemberRepository.save(projectMember);
     }
 
-    /**
-     * 프로젝트 멤버 탈퇴 수락하기
-     *
-     * @param projectMemberId
-     */
-    public void withdrawlConfirm(Long projectMemberId) {
-        ProjectMember projectMember = findById(projectMemberId);
+    @Override
+    public void delete(ProjectMember projectMember) {
         projectMemberRepository.delete(projectMember);
     }
 


### PR DESCRIPTION
### 작업내용
- 기존 프로젝트 멤버 탈퇴 컨펌 로직을 삭제하고 새로운 로직 구현
- API 엔드포인트를 `/api/projectmember/withdraw/confirm` 으로 변경하고 project_member_id 정보는 받지않도록 수정
- Long 타입의 alertId, boolean 타입의 withdrawConfirm 데이터를 Request Body로 요청받아 프로젝트 탈퇴 컨펌 로직 수행하도록 구현
- 프로젝트 탈퇴 컨펌 수락 시 project_member 엔티티를 삭제하고 해당 멤버가 프로젝트를 탈퇴했다는 확인 알림 생성