### PR TITLE
[feature/365-fix-projectmember-detail-response] 프로젝트 멤버 상세조회 응답값 수정

### DIFF
--- a/src/main/java/com/example/demo/dto/user/response/UserCrewDetailResponseDto.java
+++ b/src/main/java/com/example/demo/dto/user/response/UserCrewDetailResponseDto.java
@@ -41,7 +41,7 @@ public class UserCrewDetailResponseDto {
         return UserCrewDetailResponseDto.builder()
                 .userId(user.getId())
                 .email(user.getEmail())
-                .nickname(user.getEmail())
+                .nickname(user.getNickname())
                 .profileImgSrc(user.getProfileImgSrc())
                 .position(position)
                 .trustGrade(trustGrade)


### PR DESCRIPTION
### 작업내용
- 프로젝트 멤버 상세조회 로직에서 회원의 닉네임 값에 이메일이 셋팅되어 응답되는 버그 수정, 닉네임 값이 셋팅되도록 수정<br><br><br>
### 연관이슈
close #365 