### PR TITLE
[feature/fix-project-withdraw-confirm] 프로젝트 탈퇴 컨펌 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/constant/ProjectMemberStatus.java
+++ b/src/main/java/com/example/demo/constant/ProjectMemberStatus.java
@@ -2,5 +2,6 @@ package com.example.demo.constant;
 
 public enum ProjectMemberStatus {
     PARTICIPATING,
-    WITHDRAWLING
+    WITHDRAWLING,
+    WITHDRAW
 }

--- a/src/main/java/com/example/demo/global/exception/customexception/UserProjectHistoryCustomException.java
+++ b/src/main/java/com/example/demo/global/exception/customexception/UserProjectHistoryCustomException.java
@@ -1,0 +1,13 @@
+package com.example.demo.global.exception.customexception;
+
+import com.example.demo.global.exception.errorcode.UserProjectHistoryErrorCode;
+
+public class UserProjectHistoryCustomException extends CustomException{
+
+    public static final UserProjectHistoryCustomException NOT_FOUND_USER_PROJECT_HISTORY =
+            new UserProjectHistoryCustomException(UserProjectHistoryErrorCode.NOT_FOUND_USER_PROJECT_HISTORY);
+
+    public UserProjectHistoryCustomException(UserProjectHistoryErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/demo/global/exception/errorcode/UserProjectHistoryErrorCode.java
+++ b/src/main/java/com/example/demo/global/exception/errorcode/UserProjectHistoryErrorCode.java
@@ -1,0 +1,23 @@
+package com.example.demo.global.exception.errorcode;
+
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum UserProjectHistoryErrorCode implements ErrorCode{
+
+    NOT_FOUND_USER_PROJECT_HISTORY(HttpStatus.NOT_FOUND, "해당 회원 프로젝트 이력이 존재하지 않습니다.");
+
+    private HttpStatus status;
+    private String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return this.status;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/example/demo/model/project/ProjectMember.java
+++ b/src/main/java/com/example/demo/model/project/ProjectMember.java
@@ -56,4 +56,8 @@ public class ProjectMember extends BaseTimeEntity {
         this.status = status;
         this.position = position;
     }
+
+    public void updateStatus(ProjectMemberStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/example/demo/model/user/UserProjectHistory.java
+++ b/src/main/java/com/example/demo/model/user/UserProjectHistory.java
@@ -52,4 +52,8 @@ public class UserProjectHistory extends BaseTimeEntity {
         this.endDate = endDate;
         this.status = status;
     }
+
+    public void updateStatus(UserProjectHistoryStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepository.java
+++ b/src/main/java/com/example/demo/repository/user/UserProjectHistoryRepository.java
@@ -1,7 +1,14 @@
 package com.example.demo.repository.user;
 
+import com.example.demo.model.project.Project;
+import com.example.demo.model.user.User;
 import com.example.demo.model.user.UserProjectHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserProjectHistoryRepository
-        extends JpaRepository<UserProjectHistory, Long>, UserProjectHistoryRepositoryCustom {}
+        extends JpaRepository<UserProjectHistory, Long>, UserProjectHistoryRepositoryCustom {
+
+    Optional<UserProjectHistory> findUserProjectHistoryByProjectAndUser(Project project, User user);
+}

--- a/src/main/java/com/example/demo/service/project/ProjectMemberFacade.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberFacade.java
@@ -1,6 +1,8 @@
 package com.example.demo.service.project;
 
 import com.example.demo.constant.AlertType;
+import com.example.demo.constant.ProjectMemberStatus;
+import com.example.demo.constant.UserProjectHistoryStatus;
 import com.example.demo.dto.common.PaginationResponseDto;
 import com.example.demo.dto.position.response.PositionResponseDto;
 import com.example.demo.dto.project.request.ProjectWithdrawConfirmRequestDto;
@@ -15,10 +17,12 @@ import com.example.demo.model.project.Project;
 import com.example.demo.model.project.ProjectMember;
 import com.example.demo.model.technology_stack.TechnologyStack;
 import com.example.demo.model.user.User;
+import com.example.demo.model.user.UserProjectHistory;
 import com.example.demo.model.user.UserTechnologyStack;
 import com.example.demo.model.work.Work;
 import com.example.demo.service.alert.AlertService;
 import com.example.demo.service.trust_score.TrustScoreHistoryService;
+import com.example.demo.service.user.UserProjectHistoryService;
 import com.example.demo.service.user.UserService;
 import com.example.demo.service.work.WorkService;
 import java.util.ArrayList;
@@ -38,6 +42,7 @@ public class ProjectMemberFacade {
     private final AlertService alertService;
     private final ProjectService projectService;
     private final WorkService workService;
+    private final UserProjectHistoryService userProjectHistoryService;
     private final TrustScoreHistoryService trustScoreHistoryService;
 
     /**
@@ -83,9 +88,13 @@ public class ProjectMemberFacade {
 
         // 탈퇴 수락인 경우
         if(withdrawConfirmRequest.isWithdrawConfirm()) {
-            // 프로젝트 멤버 삭제
+            // 프로젝트 멤버 상태 탈퇴로 변경
             ProjectMember projectMember = projectMemberService.findProjectMemberByProjectAndUser(project, withdrawAlert.getSendUser());
-            projectMemberService.delete(projectMember);
+            projectMember.updateStatus(ProjectMemberStatus.WITHDRAW);
+
+            // 회원 프로젝트 이력 상태 탈퇴로 변경
+            UserProjectHistory userProjectHistory = userProjectHistoryService.getUserProjectHistoryByProjectAndUser(project, withdrawAlert.getSendUser());
+            userProjectHistory.updateStatus(UserProjectHistoryStatus.WITHDRAWAL);
 
             // 프로젝트 탈퇴 알림 생성
             Alert alert = Alert.builder()

--- a/src/main/java/com/example/demo/service/user/UserProjectHistoryService.java
+++ b/src/main/java/com/example/demo/service/user/UserProjectHistoryService.java
@@ -11,9 +11,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public interface UserProjectHistoryService {
 
-    public UserProjectHistory toUserProjectHistoryEntity(User user, Project project);
+    UserProjectHistory toUserProjectHistoryEntity(User user, Project project);
 
-    public UserProjectHistory save(UserProjectHistory userProjectHistory);
+    UserProjectHistory save(UserProjectHistory userProjectHistory);
+
+    // 프로젝트, 회원정보로 회원 프로젝트 이력 조회
+    UserProjectHistory getUserProjectHistoryByProjectAndUser(Project project, User user);
 
     // 회원 프로젝트 이력 전체 개수 조회
     Long getUserProjectHistoryTotalCount(Long userId, UserProjectHistoryStatus status);

--- a/src/main/java/com/example/demo/service/user/UserProjectHistoryServiceImpl.java
+++ b/src/main/java/com/example/demo/service/user/UserProjectHistoryServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.demo.service.user;
 
 import com.example.demo.constant.UserProjectHistoryStatus;
 import com.example.demo.dto.common.PaginationResponseDto;
+import com.example.demo.global.exception.customexception.UserProjectHistoryCustomException;
 import com.example.demo.model.project.Project;
 import com.example.demo.model.user.User;
 import com.example.demo.model.user.UserProjectHistory;
@@ -33,6 +34,13 @@ public class UserProjectHistoryServiceImpl implements UserProjectHistoryService 
     @Override
     public UserProjectHistory save(UserProjectHistory userProjectHistory) {
         return userProjectHistoryRepository.save(userProjectHistory);
+    }
+
+    @Override
+    public UserProjectHistory getUserProjectHistoryByProjectAndUser(Project project, User user) {
+        return userProjectHistoryRepository
+                .findUserProjectHistoryByProjectAndUser(project, user)
+                .orElseThrow(() -> UserProjectHistoryCustomException.NOT_FOUND_USER_PROJECT_HISTORY);
     }
 
     @Override


### PR DESCRIPTION
### 작업내용
- 프로젝트 탈퇴 컨펌 수락 시 해당 ProjectMember 엔티티를 delete() 하지 않고 ProjectMember 엔티티의 status 값을 변경하도록 수정, delete() 쿼리 실행 시 Work 엔티티와의 외래키 제약 조건으로 예외 발생
- 프로젝트 탈퇴 컨펌 수락 시 탈퇴를 요청한 회원과 프로젝트 정보를 가진 UserProjectHistory 엔티티에서 status 필드를 '탈퇴'로 변경하는 로직 추가
- ProjectMemberStatus enum 파일에 탈퇴 데이터 추가
- ProjectMember, UserProjectHistory 엔티티에 status 필드를 변경하는 로직 추가
- UserProjectHistory 에러코드 및 커스텀 예외 추가