### PR TITLE
[feature/fix-project-withdraw]프로젝트 탈퇴 신청, 알림 전송 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/controller/project/ProjectMemberController.java
+++ b/src/main/java/com/example/demo/controller/project/ProjectMemberController.java
@@ -25,8 +25,9 @@ public class ProjectMemberController {
 
     @PostMapping("/{projectMemberId}/withdraw")
     public ResponseEntity<ResponseDto<?>> withdraw(
+            @AuthenticationPrincipal PrincipalDetails user,
             @PathVariable("projectMemberId") Long projectMemberId) {
-        projectMemberFacade.sendWithdrawlAlert(projectMemberId);
+        projectMemberFacade.sendWithdrawAlert(user.getId(), projectMemberId);
         return new ResponseEntity<>(ResponseDto.success("success"), HttpStatus.OK);
     }
 

--- a/src/main/java/com/example/demo/service/project/ProjectMemberFacade.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberFacade.java
@@ -12,6 +12,7 @@ import com.example.demo.dto.trust_grade.response.TrustGradeResponseDto;
 import com.example.demo.dto.user.response.UserCrewDetailResponseDto;
 import com.example.demo.dto.user.response.UserReadProjectCrewResponseDto;
 import com.example.demo.global.exception.customexception.PageNationCustomException;
+import com.example.demo.global.exception.customexception.ProjectCustomException;
 import com.example.demo.model.alert.Alert;
 import com.example.demo.model.project.Project;
 import com.example.demo.model.project.ProjectMember;
@@ -50,19 +51,23 @@ public class ProjectMemberFacade {
      *
      * @param projectMemberId
      */
-    public void sendWithdrawlAlert(Long projectMemberId) {
+    public void sendWithdrawAlert(Long userId, Long projectMemberId) {
         ProjectMember projectMember = projectMemberService.findById(projectMemberId);
+        User user = projectMember.getUser();
 
+        if(!user.getId().equals(userId)) {
+            throw ProjectCustomException.NO_PERMISSION_TO_TASK;
+        }
+
+        Project project = projectMember.getProject();
         Alert alert =
                 Alert.builder()
-                        .project(projectMember.getProject())
-                        .checkUser(projectMember.getProject().getUser())
-                        .sendUser(projectMember.getUser())
-                        .work(null)
-                        .milestone(null)
-                        .content("프로젝트 지원했습니다.")
+                        .project(project)
+                        .checkUser(project.getUser())
+                        .sendUser(user)
+                        .content(user.getNickname() + "님이 프로젝트 탈퇴 신청을 했습니다.")
                         .position(projectMember.getPosition())
-                        .type(AlertType.RECRUIT)
+                        .type(AlertType.WITHDRAWL)
                         .checked_YN(false)
                         .build();
 


### PR DESCRIPTION
### 작업내용
- 프로젝트 탈퇴 신청 로직에 요청받은 projectMemberId 값으로 멤버를 조회하고 해당 멤버의 회원 정보와 요청한 회원 정보를 비교, 검증하는 로직 추가
- 프로젝트 탈퇴 신청 알림 생성 시 지원/모집 알림 값으로 셋팅하는 버그 수정