### PR TITLE
[feature/366-alert-nullable] 알림 엔티티 null 관련 작업

### DIFF
--- a/src/main/java/com/example/demo/dto/alert/request/AlertCreateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/alert/request/AlertCreateRequestDto.java
@@ -17,10 +17,8 @@ public class AlertCreateRequestDto {
     @NotNull(message = "프로젝트 아이디는 필수입니다.")
     private Long projectId;
 
-    @NotNull(message = "체크해야 하는 유저 아이디는 필수입니다.")
     private Long checkUserId;
 
-    @NotNull(message = "보내는 유저 아이디는 필수입니다.")
     private Long sendUserId;
 
     private Long workId;

--- a/src/main/java/com/example/demo/model/alert/Alert.java
+++ b/src/main/java/com/example/demo/model/alert/Alert.java
@@ -30,7 +30,7 @@ public class Alert extends BaseTimeEntity {
     private User checkUser;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "send_user_id", referencedColumnName = "user_id", nullable = false)
+    @JoinColumn(name = "send_user_id", referencedColumnName = "user_id")
     private User sendUser;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/demo/service/alert/AlertFacade.java
+++ b/src/main/java/com/example/demo/service/alert/AlertFacade.java
@@ -38,11 +38,20 @@ public class AlertFacade {
      */
     public void send(AlertCreateRequestDto alertCreateRequestDto) {
         Project project = projectService.findById(alertCreateRequestDto.getProjectId());
-        User checkUser = userService.findById(alertCreateRequestDto.getCheckUserId());
-        User sendUser = userService.findById(alertCreateRequestDto.getSendUserId());
+        User checkUser = null;
+        User sendUser = null;
         Work work = null;
         Milestone milestone = null;
         Position position = null;
+
+        if (alertCreateRequestDto.getCheckUserId() != null) {
+            checkUser = userService.findById(alertCreateRequestDto.getCheckUserId());
+        }
+
+        if(alertCreateRequestDto.getSendUserId() != null) {
+            sendUser = userService.findById(alertCreateRequestDto.getSendUserId());
+        }
+
         if (alertCreateRequestDto.getWorkId() != null) {
             work = workService.findById(alertCreateRequestDto.getWorkId());
         }


### PR DESCRIPTION
### 작업내용
- 알림 엔티티 sendUser 필드에 null 값을 허용하도록 nullable 속성 제거
- 알림 생성 요청 DTO에서 checkUserId, sendUserId 필드가 null 값을 허용하도록 `@NotNull` 어노테이션 제거
- 알림 생성 로직에서 checkUserId, sendUserId 필드가 null 값을 허용하므로 null 체크 로직 추가 및 수정<br><br><br>
### 연관이슈
close #366 