### PR TITLE
[feature/fix-alert-send] 알림 전송 로직 sendUser 데이터 셋팅 수정

### DIFF
--- a/src/main/java/com/example/demo/service/alert/AlertFacade.java
+++ b/src/main/java/com/example/demo/service/alert/AlertFacade.java
@@ -12,6 +12,7 @@ import com.example.demo.model.user.User;
 import com.example.demo.model.work.Work;
 import com.example.demo.service.milestone.MilestoneService;
 import com.example.demo.service.position.PositionService;
+import com.example.demo.service.project.ProjectMemberService;
 import com.example.demo.service.project.ProjectService;
 import com.example.demo.service.user.UserService;
 import com.example.demo.service.work.WorkService;
@@ -26,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AlertFacade {
     private final AlertService alertService;
     private final ProjectService projectService;
+    private final ProjectMemberService projectMemberService;
     private final UserService userService;
     private final WorkService workService;
     private final PositionService positionService;
@@ -49,7 +51,8 @@ public class AlertFacade {
         }
 
         if(alertCreateRequestDto.getSendUserId() != null) {
-            sendUser = userService.findById(alertCreateRequestDto.getSendUserId());
+            // 클라이언트로부터 해당 회원의 project_member_id 정보를 요청받음
+            sendUser = projectMemberService.findById(alertCreateRequestDto.getSendUserId()).getUser();
         }
 
         if (alertCreateRequestDto.getWorkId() != null) {


### PR DESCRIPTION
### 작업내용
- 클라이언트로부터 sendUserd 정보는 project_member_id 데이터로 요청받아 알림 전송 로직에서 project_member_id의 프로젝트 멤버를 조회하고 해당 멤버의 회원 정보를 sendUser에 셋팅하도록 수정