### PR TITLE
[feature/381-fix-get-alerts-by-condition] 각 조건별 알림 목록 조회 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/controller/alert/AlertController.java
+++ b/src/main/java/com/example/demo/controller/alert/AlertController.java
@@ -36,28 +36,35 @@ public class AlertController {
             @PathVariable("projectId") Long projectId,
             @RequestParam("pageIndex") Optional<Integer> pageIndex,
             @RequestParam("itemCount") Optional<Integer> itemCount) {
-        return new ResponseEntity<>(ResponseDto.success("success", alertFacade.getAllByProject(projectId, pageIndex.orElse(0), itemCount.orElse(6))), HttpStatus.OK);
+        return new ResponseEntity<>(ResponseDto.success("success",
+                alertFacade.getAllByProject(projectId, pageIndex.orElse(0), itemCount.orElse(6))), HttpStatus.OK);
     }
 
     @GetMapping("/api/alert/project/{projectId}/recruits")
     public ResponseEntity<ResponseDto<?>> getRecruitsByProject(
-            @PathVariable("projectId") Long projectId) {
-        List<AlertInfoResponseDto> result = alertFacade.getRecruitsByProject(projectId);
-        return new ResponseEntity<>(ResponseDto.success("success", result), HttpStatus.OK);
+            @PathVariable("projectId") Long projectId,
+            @RequestParam("pageIndex") Optional<Integer> pageIndex,
+            @RequestParam("itemCount") Optional<Integer> itemCount) {
+        return new ResponseEntity<>(ResponseDto.success("success",
+                alertFacade.getRecruitsByProject(projectId, pageIndex.orElse(0), itemCount.orElse(6))), HttpStatus.OK);
     }
 
     @GetMapping("/api/alert/project/{projectId}/works")
     public ResponseEntity<ResponseDto<?>> getWorksByProject(
-            @PathVariable("projectId") Long projectId) {
-        List<AlertInfoResponseDto> result = alertFacade.getWorksByProject(projectId);
-        return new ResponseEntity<>(ResponseDto.success("success", result), HttpStatus.OK);
+            @PathVariable("projectId") Long projectId,
+            @RequestParam("pageIndex") Optional<Integer> pageIndex,
+            @RequestParam("itemCount") Optional<Integer> itemCount) {
+        return new ResponseEntity<>(ResponseDto.success("success",
+                alertFacade.getWorksByProject(projectId, pageIndex.orElse(0), itemCount.orElse(6))), HttpStatus.OK);
     }
 
     @GetMapping("/api/alert/project/{projectId}/crews")
     public ResponseEntity<ResponseDto<?>> getCrewsByProject(
-            @PathVariable("projectId") Long projectId) {
-        List<AlertInfoResponseDto> result = alertFacade.getCrewsByProject(projectId);
-        return new ResponseEntity<>(ResponseDto.success("success", result), HttpStatus.OK);
+            @PathVariable("projectId") Long projectId,
+            @RequestParam("pageIndex") Optional<Integer> pageIndex,
+            @RequestParam("itemCount") Optional<Integer> itemCount) {
+        return new ResponseEntity<>(ResponseDto.success("success",
+                alertFacade.getCrewsByProject(projectId, pageIndex.orElse(0), itemCount.orElse(6))), HttpStatus.OK);
     }
 
     @PutMapping("/api/alert/{alertId}/status")

--- a/src/main/java/com/example/demo/repository/alert/AlertRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/alert/AlertRepositoryCustom.java
@@ -1,14 +1,21 @@
 package com.example.demo.repository.alert;
 
+import com.example.demo.constant.AlertType;
 import com.example.demo.dto.alert.response.AlertInfoResponseDto;
+import com.example.demo.dto.alert.response.AlertSupportedProjectInfoResponseDto;
 import com.example.demo.dto.common.PaginationResponseDto;
 import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface AlertRepositoryCustom {
 
     // 프로젝트 알람 목록 조회(페이징, 최신순 정렬)
-    PaginationResponseDto findAlertsByProjectIdOrderByCreateDateDesc(Long projectId, Pageable pageable);
+    List<AlertInfoResponseDto> findAlertsByProjectIdOrTypeOrderByCreateDateDesc(Long projectId, AlertType type, Pageable pageable);
 
     // 사용자가 지원한 프로젝트 알람 목록 조회(페이징, 최신순 정렬)
-    PaginationResponseDto findAlertsBySendUserIdAndTypeOrderByCreateDateDesc(Long sendUserId, Pageable pageable);
+    List<AlertSupportedProjectInfoResponseDto> findAlertsBySendUserIdAndTypeOrderByCreateDateDesc(Long sendUserId, Pageable pageable);
+
+    // 조건별 알림 목록 개수 조회
+    long countAlertsTotalItem(Long projectId, Long sendUserId, AlertType type);
 }

--- a/src/main/java/com/example/demo/service/alert/AlertFacade.java
+++ b/src/main/java/com/example/demo/service/alert/AlertFacade.java
@@ -1,5 +1,6 @@
 package com.example.demo.service.alert;
 
+import com.example.demo.constant.AlertType;
 import com.example.demo.dto.alert.AlertCreateRequestDto;
 import com.example.demo.dto.alert.response.AlertInfoResponseDto;
 import com.example.demo.dto.common.PaginationResponseDto;
@@ -74,55 +75,46 @@ public class AlertFacade {
     }
 
     public PaginationResponseDto getAllByProject(Long projectId, int pageIndex, int itemCount) {
+        verifiedPageIndex(pageIndex);
+        verifiedItemCount(itemCount);
+
         Project project = projectService.findById(projectId);
-
-        if(pageIndex < 0) {
-            throw PageNationCustomException.INVALID_PAGE_NUMBER;
-        }
-
-        if(itemCount < 0 || itemCount > 8) {
-            throw PageNationCustomException.INVALID_PAGE_ITEM_COUNT;
-        }
-
-        PaginationResponseDto alerts = alertService.findAlertsByProjectId(project, pageIndex, itemCount);
+        PaginationResponseDto alerts = alertService.findAlertsByProjectIdAndType(project, null, pageIndex, itemCount);
 
         return alerts;
     }
 
-    public List<AlertInfoResponseDto> getRecruitsByProject(Long projectId) {
+    public PaginationResponseDto getRecruitsByProject(Long projectId, int pageIndex, int itemCount) {
+        verifiedPageIndex(pageIndex);
+        verifiedItemCount(itemCount);
+
         Project project = projectService.findById(projectId);
-        List<Alert> alerts = alertService.findRecruitAlertsByProject(project);
-        List<AlertInfoResponseDto> alertInfoResponseDtos = new ArrayList<>();
+        PaginationResponseDto alerts = alertService
+                .findAlertsByProjectIdAndType(project, AlertType.RECRUIT, pageIndex, itemCount);
 
-        for (Alert alert : alerts) {
-            alertInfoResponseDtos.add(AlertInfoResponseDto.of(alert, alert.getPosition()));
-        }
-
-        return alertInfoResponseDtos;
+        return alerts;
     }
 
-    public List<AlertInfoResponseDto> getWorksByProject(Long projectId) {
+    public PaginationResponseDto getWorksByProject(Long projectId, int pageIndex, int itemCount) {
+        verifiedPageIndex(pageIndex);
+        verifiedItemCount(itemCount);
+
         Project project = projectService.findById(projectId);
-        List<Alert> alerts = alertService.findWorkAlertsByProject(project);
-        List<AlertInfoResponseDto> alertInfoResponseDtos = new ArrayList<>();
+        PaginationResponseDto alerts = alertService
+                .findAlertsByProjectIdAndType(project, AlertType.WORK, pageIndex, itemCount);
 
-        for (Alert alert : alerts) {
-            alertInfoResponseDtos.add(AlertInfoResponseDto.of(alert, alert.getPosition()));
-        }
-
-        return alertInfoResponseDtos;
+        return alerts;
     }
 
-    public List<AlertInfoResponseDto> getCrewsByProject(Long projectId) {
+    public PaginationResponseDto getCrewsByProject(Long projectId, int pageIndex, int itemCount) {
+        verifiedPageIndex(pageIndex);
+        verifiedItemCount(itemCount);
+
         Project project = projectService.findById(projectId);
-        List<Alert> alerts = alertService.findCrewAlertsByProject(project);
-        List<AlertInfoResponseDto> alertInfoResponseDtos = new ArrayList<>();
+        PaginationResponseDto alerts = alertService
+                .findAlertsByProjectIdAndType(project, AlertType.ADD, pageIndex, itemCount);
 
-        for (Alert alert : alerts) {
-            alertInfoResponseDtos.add(AlertInfoResponseDto.of(alert, alert.getPosition()));
-        }
-
-        return alertInfoResponseDtos;
+        return alerts;
     }
 
     @Transactional(readOnly = true)
@@ -134,5 +126,17 @@ public class AlertFacade {
         User currentUser = userService.findById(userId);
 
         return alertService.findAlertsBySendUserIdAndType(currentUser, pageIndex, itemCount);
+    }
+
+    private void verifiedPageIndex(int pageIndex) {
+        if(pageIndex < 0) {
+            throw PageNationCustomException.INVALID_PAGE_NUMBER;
+        }
+    }
+
+    private void verifiedItemCount(int itemCount) {
+        if(itemCount < 0 || itemCount > 8) {
+            throw PageNationCustomException.INVALID_PAGE_ITEM_COUNT;
+        }
     }
 }

--- a/src/main/java/com/example/demo/service/alert/AlertService.java
+++ b/src/main/java/com/example/demo/service/alert/AlertService.java
@@ -1,5 +1,6 @@
 package com.example.demo.service.alert;
 
+import com.example.demo.constant.AlertType;
 import com.example.demo.dto.common.PaginationResponseDto;
 import com.example.demo.model.alert.Alert;
 import com.example.demo.model.project.Project;
@@ -15,13 +16,7 @@ public interface AlertService {
 
     Alert save(Alert alert);
 
-    PaginationResponseDto findAlertsByProjectId(Project project, int pageIndex, int itemCount);
-
-    List<Alert> findRecruitAlertsByProject(Project project);
-
-    List<Alert> findWorkAlertsByProject(Project project);
-
-    List<Alert> findCrewAlertsByProject(Project project);
+    PaginationResponseDto findAlertsByProjectIdAndType(Project project, AlertType type, int pageIndex, int itemCount);
 
     void updateAlertStatus(Long alertId);
 

--- a/src/main/java/com/example/demo/service/alert/AlertServiceImpl.java
+++ b/src/main/java/com/example/demo/service/alert/AlertServiceImpl.java
@@ -1,6 +1,8 @@
 package com.example.demo.service.alert;
 
+import com.example.demo.constant.AlertType;
 import com.example.demo.dto.alert.response.AlertInfoResponseDto;
+import com.example.demo.dto.alert.response.AlertSupportedProjectInfoResponseDto;
 import com.example.demo.dto.common.PaginationResponseDto;
 import com.example.demo.global.exception.customexception.AlertCustomException;
 import com.example.demo.model.alert.Alert;
@@ -27,27 +29,13 @@ public class AlertServiceImpl implements AlertService {
         return alertRepository.save(alert);
     }
 
-    public PaginationResponseDto findAlertsByProjectId(Project project, int pageIndex, int itemCount) {
-        return alertRepository
-                .findAlertsByProjectIdOrderByCreateDateDesc(project.getId(), PageRequest.of(pageIndex, itemCount));
-    }
+    public PaginationResponseDto findAlertsByProjectIdAndType(Project project, AlertType type, int pageIndex, int itemCount) {
+        List<AlertInfoResponseDto> content = alertRepository
+                                                .findAlertsByProjectIdOrTypeOrderByCreateDateDesc(project.getId(), type, PageRequest.of(pageIndex, itemCount));
 
-    public List<Alert> findRecruitAlertsByProject(Project project) {
-        return alertRepository
-                .findRecruitAlertsByProject(project)
-                .orElseThrow(() -> AlertCustomException.NOT_FOUND_ALERT);
-    }
+        long totalPages = alertRepository.countAlertsTotalItem(project.getId(), null, type);
 
-    public List<Alert> findWorkAlertsByProject(Project project) {
-        return alertRepository
-                .findWorkAlertsByProject(project)
-                .orElseThrow(() -> AlertCustomException.NOT_FOUND_ALERT);
-    }
-
-    public List<Alert> findCrewAlertsByProject(Project project) {
-        return alertRepository
-                .findCrewAlertsByProject(project)
-                .orElseThrow(() -> AlertCustomException.NOT_FOUND_ALERT);
+        return PaginationResponseDto.of(content, totalPages);
     }
 
     @Override
@@ -57,7 +45,11 @@ public class AlertServiceImpl implements AlertService {
 
     @Override
     public PaginationResponseDto findAlertsBySendUserIdAndType(User user, int pageIndex, int itemCount) {
-        return alertRepository
-                .findAlertsBySendUserIdAndTypeOrderByCreateDateDesc(user.getId(), PageRequest.of(pageIndex, itemCount));
+        List<AlertSupportedProjectInfoResponseDto> content = alertRepository
+                                                                .findAlertsBySendUserIdAndTypeOrderByCreateDateDesc(user.getId(), PageRequest.of(pageIndex, itemCount));
+
+        long totalPages = alertRepository.countAlertsTotalItem(null, user.getId(), AlertType.RECRUIT);
+
+        return PaginationResponseDto.of(content, totalPages);
     }
 }


### PR DESCRIPTION
### 작업 API
- `/api/alert/project/{projectId}/recruits`: 프로젝트 모집알림 목록 조회
- `/api/alert/project/{projectId}/works`: 프로젝트 업무 알림목록 조회
- `/api/alert/project/{projectId}/crews`: 프로젝트 크루 알림목록 조회

### 작업내용
- 위의 3가지 로직을 특정 프로젝트의 전체 알림 목록을 조회하는 api인 `/api/alert/project/{projectId}`와 동일하게 페이징과 정렬을 적용해 데이터 목록을 응답하도록 수정
- 기존 프로젝트 알림 목록 조회 쿼리를 함께 공유하기 위해 로직 수정
    - 동적 조건 쿼리를 추가해 각 조건에 맞는 데이터 목록을 하나의 쿼리 메소드에서 조회하도록 수정
    - 각 조건별 알림 데이터 개수를 조회하기 위해 기존 프로젝트 알림 목록 조회 쿼리에서 알림 데이터 개수를 조회하는 로직을 분리하고 public 메소드로 변경하여 service layer에서 각 조건별로 호출할 수 있도록 변경
- 요청한 페이징 관련 데이터를 검증하는 공통 로직을 따로 메소드화해서 분리
<br><br><br>
### 연관이슈
close #381 