### PR TITLE
[feature/fix-user-supproted-projects] 사용자가 지원한 프로젝트 일림목록 조회 수정

### DIFF
--- a/src/main/java/com/example/demo/dto/alert/response/AlertSupportedProjectInfoResponseDto.java
+++ b/src/main/java/com/example/demo/dto/alert/response/AlertSupportedProjectInfoResponseDto.java
@@ -9,9 +9,9 @@ public class AlertSupportedProjectInfoResponseDto {
 
     private ProjectSimpleInfoResponseDto project;
     private PositionInfoResponseDto position;
-    private boolean supportResult;
+    private Boolean supportResult;
 
-    public AlertSupportedProjectInfoResponseDto(ProjectSimpleInfoResponseDto project, PositionInfoResponseDto position, boolean supportResult) {
+    public AlertSupportedProjectInfoResponseDto(ProjectSimpleInfoResponseDto project, PositionInfoResponseDto position, Boolean supportResult) {
         this.project = project;
         this.position = position;
         this.supportResult = supportResult;


### PR DESCRIPTION
### 작업내용
- 기존 사용자가 지원한 프로젝트 알림목록 조회 시 응답하는 AlertSupprotedProjectInfoResponse DTO에서 참여지원 결과 데이터 supportResult 필드의 타입을 null 값도 응답하기 위해 boolean -> Boolean 타입으로 변경