### PR TITLE
[feature/fix-user-participate-supported-project-alerts-response] 사용자가 참여지원한 프로젝트 알림 목록 조회 응답값 수정

### DIFF
--- a/src/main/java/com/example/demo/dto/alert/response/AlertSupportedProjectInfoResponseDto.java
+++ b/src/main/java/com/example/demo/dto/alert/response/AlertSupportedProjectInfoResponseDto.java
@@ -7,11 +7,13 @@ import lombok.Getter;
 @Getter
 public class AlertSupportedProjectInfoResponseDto {
 
+    private Long alertId;
     private ProjectSimpleInfoResponseDto project;
     private PositionInfoResponseDto position;
     private Boolean supportResult;
 
-    public AlertSupportedProjectInfoResponseDto(ProjectSimpleInfoResponseDto project, PositionInfoResponseDto position, Boolean supportResult) {
+    public AlertSupportedProjectInfoResponseDto(Long alertId, ProjectSimpleInfoResponseDto project, PositionInfoResponseDto position, Boolean supportResult) {
+        this.alertId = alertId;
         this.project = project;
         this.position = position;
         this.supportResult = supportResult;

--- a/src/main/java/com/example/demo/repository/alert/AlertRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/alert/AlertRepositoryImpl.java
@@ -81,6 +81,7 @@ public class AlertRepositoryImpl implements AlertRepositoryCustom{
                 .select(
                         Projections.constructor(
                                 AlertSupportedProjectInfoResponseDto.class,
+                                qAlert.id,
                                 Projections.constructor(
                                         ProjectSimpleInfoResponseDto.class,
                                         qProject.id,


### PR DESCRIPTION
### 작업내용
- 사용자가 참여지원한 프로젝트에 대한 알림목록을 조회하는 로직의 응답 값에 해당 알림의 ID(PK) 값 추가
- 사용자가 참여지원한 프로젝트 알림목록 조회 쿼리에 해당 알림 데이터의 ID(PK) 값을 AlertSupportedProjectInfoResponse DTO에 함께 셋팅하도록 수정