### PR TITLE
[feature/389-fix-alert-check-status-update] 알림 확인상태 변경 로직 버그 해결 및 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/controller/alert/AlertController.java
+++ b/src/main/java/com/example/demo/controller/alert/AlertController.java
@@ -67,10 +67,10 @@ public class AlertController {
                 alertFacade.getCrewsByProject(projectId, pageIndex.orElse(0), itemCount.orElse(6))), HttpStatus.OK);
     }
 
-    @PutMapping("/api/alert/{alertId}/status")
+    @PatchMapping("/api/alert/{alertId}/status")
     public ResponseEntity<ResponseDto<?>> updateAlertStatus(@PathVariable Long alertId) {
         alertService.updateAlertStatus(alertId);
-        return new ResponseEntity<>(ResponseDto.success("success", null), HttpStatus.OK);
+        return new ResponseEntity<>(ResponseDto.success("success"), HttpStatus.OK);
     }
 
     @GetMapping("/api/alert/supported-projects")

--- a/src/main/java/com/example/demo/model/alert/Alert.java
+++ b/src/main/java/com/example/demo/model/alert/Alert.java
@@ -83,4 +83,8 @@ public class Alert extends BaseTimeEntity {
     public void updateProjectConfirmResult(boolean projectConfirmResult) {
         this.projectConfirmResult = projectConfirmResult;
     }
+
+    public void updateCheckedStatusIsTrue() {
+        this.checked_YN = true;
+    }
 }

--- a/src/main/java/com/example/demo/repository/alert/AlertRepository.java
+++ b/src/main/java/com/example/demo/repository/alert/AlertRepository.java
@@ -24,7 +24,4 @@ public interface AlertRepository extends JpaRepository<Alert, Long>, AlertReposi
     @Query(
             "select alert from Alert alert where alert.project = :#{#project} and (alert.type = com.example.demo.constant.AlertType.ADD or alert.type = com.example.demo.constant.AlertType.WITHDRAWL or alert.type = com.example.demo.constant.AlertType.FORCEDWITHDRAWL)")
     Optional<List<Alert>> findCrewAlertsByProject(@Param(value = "project") Project project);
-    @Modifying
-    @Query("update Alert alert set alert.checked_YN = true where alert.id = :alertId")
-    void updateAlertStatus(@Param(value = "alertId") Long alertId);
 }

--- a/src/main/java/com/example/demo/service/alert/AlertService.java
+++ b/src/main/java/com/example/demo/service/alert/AlertService.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import com.example.demo.model.user.User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public interface AlertService {
@@ -18,6 +19,7 @@ public interface AlertService {
 
     PaginationResponseDto findAlertsByProjectIdAndType(Project project, AlertType type, int pageIndex, int itemCount);
 
+    @Transactional
     void updateAlertStatus(Long alertId);
 
     PaginationResponseDto findAlertsBySendUserIdAndType(User user, int pageIndex, int itemCount);

--- a/src/main/java/com/example/demo/service/alert/AlertServiceImpl.java
+++ b/src/main/java/com/example/demo/service/alert/AlertServiceImpl.java
@@ -40,7 +40,11 @@ public class AlertServiceImpl implements AlertService {
 
     @Override
     public void updateAlertStatus(Long alertId) {
-        alertRepository.updateAlertStatus(alertId);
+        Alert alert = alertRepository
+                .findById(alertId)
+                .orElseThrow(() -> AlertCustomException.NOT_FOUND_ALERT);
+
+        alert.updateCheckedStatusIsTrue();
     }
 
     @Override


### PR DESCRIPTION
### 작업내용
- 기존 알림 확인상태를 true(확인)로 변경하는 로직에 `@Transactional` 어노테이션이 없어 발생한 오류 해결
- 기존 Repository에서 요청한 알림 데이터의 확인상태 수정 작업을 처리하던 방법에서 Alert 엔티티에서 처리하도록 updateCheckedStatusIsTrue() 메소드 추가
- 알림 확인상태 변경 api의 HttpMethod를 `PutMapping` -> `PatchMapping`으로 변경<br><br><br>
### 연관이슈
close #389 