### PR TITLE
[feature/392-fix-alerts-info-response] 알림 정보 응답 수정

### DIFF
--- a/src/main/java/com/example/demo/dto/alert/response/AlertInfoResponseDto.java
+++ b/src/main/java/com/example/demo/dto/alert/response/AlertInfoResponseDto.java
@@ -32,9 +32,11 @@ public class AlertInfoResponseDto {
     @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
     private LocalDateTime updateDate;
 
+    private boolean checkedStatus;
+
     public AlertInfoResponseDto(Long alertId, Long projectId, Long checkUserId, Long sendUserId,
                                 Long workId, Long milestoneId, PositionInfoResponseDto position,
-                                String content, AlertType type, LocalDateTime createDate, LocalDateTime updateDate) {
+                                String content, AlertType type, LocalDateTime createDate, LocalDateTime updateDate, boolean checkedStatus) {
         this.alertId = alertId;
         this.projectId = projectId;
         this.checkUserId = checkUserId;
@@ -46,6 +48,7 @@ public class AlertInfoResponseDto {
         this.type = type;
         this.createDate = createDate;
         this.updateDate = updateDate;
+        this.checkedStatus = checkedStatus;
     }
 
     public static AlertInfoResponseDto of(Alert alert, Position position) {
@@ -67,6 +70,7 @@ public class AlertInfoResponseDto {
                 .type(alert.getType())
                 .createDate(alert.getCreateDate())
                 .updateDate(alert.getUpdateDate())
+                .checkedStatus(alert.isChecked_YN())
                 .build();
     }
 }

--- a/src/main/java/com/example/demo/repository/alert/AlertRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/alert/AlertRepositoryImpl.java
@@ -55,7 +55,8 @@ public class AlertRepositoryImpl implements AlertRepositoryCustom{
                                 qAlert.content,
                                 qAlert.type,
                                 qAlert.createDate,
-                                qAlert.updateDate
+                                qAlert.updateDate,
+                                qAlert.checked_YN
                         )
                 )
                 .from(qAlert)


### PR DESCRIPTION
### 작업내용
- 알림 정보 응답 데이터에 boolean 타입의 알림 확인 여부 `checkedStatus` 필드 추가
- 알림 정보를 조회하는 쿼리에서 Alert 엔티티의 checked_YN 필드를 조회 및 셋팅하도록 수정<br><br><br>
### 연관이슈
close #392 