### PR TITLE
[feature/396-fix-project-end] 프로젝트 종료 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/controller/project/ProjectController.java
+++ b/src/main/java/com/example/demo/controller/project/ProjectController.java
@@ -73,8 +73,10 @@ public class ProjectController {
     }
 
     @PostMapping("/{projectId}/end")
-    public ResponseEntity<ResponseDto<?>> end(@PathVariable("projectId") Long projectId) {
-        projectService.end(projectId);
-        return new ResponseEntity<>(ResponseDto.success("success", null), HttpStatus.OK);
+    public ResponseEntity<ResponseDto<?>> end(
+            @PathVariable("projectId") Long projectId,
+            @AuthenticationPrincipal PrincipalDetails user) {
+        projectFacade.endProject(user.getId(), projectId);
+        return new ResponseEntity<>(ResponseDto.success("success"), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/demo/model/project/Project.java
+++ b/src/main/java/com/example/demo/model/project/Project.java
@@ -92,4 +92,12 @@ public class Project extends BaseTimeEntity {
         this.projectTechnologies.clear();
         this.projectTechnologies.addAll(projectTechnologies);
     }
+
+    public void removeProjectMembers() {
+        this.projectMembers.clear();
+    }
+
+    public void removeProjectTechnologies() {
+        this.projectTechnologies.clear();
+    }
 }

--- a/src/main/java/com/example/demo/repository/alert/AlertRepository.java
+++ b/src/main/java/com/example/demo/repository/alert/AlertRepository.java
@@ -24,4 +24,6 @@ public interface AlertRepository extends JpaRepository<Alert, Long>, AlertReposi
     @Query(
             "select alert from Alert alert where alert.project = :#{#project} and (alert.type = com.example.demo.constant.AlertType.ADD or alert.type = com.example.demo.constant.AlertType.WITHDRAWL or alert.type = com.example.demo.constant.AlertType.FORCEDWITHDRAWL)")
     Optional<List<Alert>> findCrewAlertsByProject(@Param(value = "project") Project project);
+
+    void deleteAllByProject(Project project);
 }

--- a/src/main/java/com/example/demo/repository/milestone/MileStoneRepository.java
+++ b/src/main/java/com/example/demo/repository/milestone/MileStoneRepository.java
@@ -11,4 +11,6 @@ public interface MileStoneRepository extends JpaRepository<Milestone, Long> {
     Optional<Milestone> findById(Long id);
 
     Optional<List<Milestone>> findMilestonesByProject(Project project);
+
+    void deleteAllByProject(Project project);
 }

--- a/src/main/java/com/example/demo/repository/work/WorkRepository.java
+++ b/src/main/java/com/example/demo/repository/work/WorkRepository.java
@@ -14,4 +14,6 @@ public interface WorkRepository extends JpaRepository<Work, Long>, WorkRepositor
 
     Optional<Work> findFirstByProjectAndAssignedUserIdAndProgressStatusOrderByIdDesc(
             Project project, User user, ProgressStatus progressStatus);
+
+    void deleteAllByProject(Project project);
 }

--- a/src/main/java/com/example/demo/service/alert/AlertService.java
+++ b/src/main/java/com/example/demo/service/alert/AlertService.java
@@ -23,4 +23,6 @@ public interface AlertService {
     void updateAlertStatus(Long alertId);
 
     PaginationResponseDto findAlertsBySendUserIdAndType(User user, int pageIndex, int itemCount);
+
+    void deleteAllByProject(Project project);
 }

--- a/src/main/java/com/example/demo/service/alert/AlertServiceImpl.java
+++ b/src/main/java/com/example/demo/service/alert/AlertServiceImpl.java
@@ -56,4 +56,9 @@ public class AlertServiceImpl implements AlertService {
 
         return PaginationResponseDto.of(content, totalPages);
     }
+
+    @Override
+    public void deleteAllByProject(Project project) {
+        alertRepository.deleteAllByProject(project);
+    }
 }

--- a/src/main/java/com/example/demo/service/milestone/MilestoneService.java
+++ b/src/main/java/com/example/demo/service/milestone/MilestoneService.java
@@ -29,4 +29,6 @@ public interface MilestoneService {
 
     public void updateDate(
             Long milestoneId, MilestoneUpdateDateRequestDto milestoneUpdateDateRequestDto);
+
+    void deleteAllByProject(Project project);
 }

--- a/src/main/java/com/example/demo/service/milestone/MilestoneServiceImpl.java
+++ b/src/main/java/com/example/demo/service/milestone/MilestoneServiceImpl.java
@@ -67,4 +67,9 @@ public class MilestoneServiceImpl implements MilestoneService {
         Milestone milestone = findById(milestoneId);
         milestone.updateDate(milestoneUpdateDateRequestDto);
     }
+
+    @Override
+    public void deleteAllByProject(Project project) {
+        mileStoneRepository.deleteAllByProject(project);
+    }
 }

--- a/src/main/java/com/example/demo/service/project/ProjectFacade.java
+++ b/src/main/java/com/example/demo/service/project/ProjectFacade.java
@@ -1,8 +1,6 @@
 package com.example.demo.service.project;
 
-import com.example.demo.constant.AlertType;
-import com.example.demo.constant.ProjectMemberStatus;
-import com.example.demo.constant.UserProjectHistoryStatus;
+import com.example.demo.constant.*;
 import com.example.demo.dto.common.PaginationResponseDto;
 import com.example.demo.dto.project.request.ProjectConfirmRequestDto;
 import com.example.demo.dto.project.request.ProjectParticipateRequestDto;
@@ -11,10 +9,7 @@ import com.example.demo.dto.project.response.ProjectSpecificDetailResponseDto;
 import com.example.demo.dto.projectmember.response.MyProjectMemberResponseDto;
 import com.example.demo.dto.trust_grade.response.TrustGradeResponseDto;
 import com.example.demo.dto.user.response.UserMyProjectResponseDto;
-import com.example.demo.global.exception.customexception.CommonCustomException;
-import com.example.demo.global.exception.customexception.PageNationCustomException;
-import com.example.demo.global.exception.customexception.ProjectCustomException;
-import com.example.demo.global.exception.customexception.UserCustomException;
+import com.example.demo.global.exception.customexception.*;
 import com.example.demo.model.alert.Alert;
 import com.example.demo.model.position.Position;
 import com.example.demo.model.project.Project;
@@ -213,5 +208,53 @@ public class ProjectFacade {
 
         // 프로젝트 참여 거절
         supportedAlert.updateProjectConfirmResult(false);
+    }
+
+    /**
+     * 프로젝트 종료
+     * 해당 프로젝트 멤버의 새로운 사용자 프로젝트 이력 추가(프로젝트 완주 이력)
+     * 해당 프로젝트와 관련된 업무, 마일스톤, 알림, 멤버, 기술스택 정보 삭제
+     * @param userId
+     * @param projectId
+     */
+    @Transactional
+    public void endProject(Long userId, Long projectId) {
+        User currentUser = userService.findById(userId);
+        Project project = projectService.findById(projectId);
+
+        // 요청한 회원 프로젝트 매니저 검증
+        ProjectMemberAuth projectMemberAuth = projectMemberService.findProjectMemberByProjectAndUser(project, currentUser).getProjectMemberAuth();
+        ProjectRole projectRole = ProjectRole.findProjectRole(projectMemberAuth.getId());
+        if(!projectRole.isManager()) {
+            throw ProjectMemberAuthCustomException.INSUFFICIENT_PROJECT_AUTH;
+        }
+
+        for(ProjectMember projectMember : project.getProjectMembers()) {
+            // 프로젝트 멤버 프로젝트 완주 이력 추가
+            UserProjectHistory projectFinishHistory = UserProjectHistory.builder()
+                    .project(project)
+                    .user(projectMember.getUser())
+                    .status(UserProjectHistoryStatus.FINISH)
+                    .build();
+            userProjectHistoryService.save(projectFinishHistory);
+        }
+
+        // 프로젝트 멤버 삭제
+        project.removeProjectMembers();
+
+        // 프로젝트 기술목록 삭제
+        project.removeProjectTechnologies();
+
+        // 프로젝트 모든 업무 삭제
+        workService.deleteAllByProject(project);
+
+        // 프로젝트 모든 마일스톤 삭제
+        milestoneService.deleteAllByProject(project);
+
+        // 프로젝트 관련 모든 알림 삭제
+        alertService.deleteAllByProject(project);
+
+        // 프로젝트 status 종료로 변경
+        project.endProject();
     }
 }

--- a/src/main/java/com/example/demo/service/project/ProjectService.java
+++ b/src/main/java/com/example/demo/service/project/ProjectService.java
@@ -15,6 +15,4 @@ public interface ProjectService {
     public List<Project> findProjectsByUser(User user);
 
     public int countProjectsByUser(User user);
-
-    public void end(Long projectId);
 }

--- a/src/main/java/com/example/demo/service/project/ProjectServiceImpl.java
+++ b/src/main/java/com/example/demo/service/project/ProjectServiceImpl.java
@@ -33,14 +33,4 @@ public class ProjectServiceImpl implements ProjectService {
     public int countProjectsByUser(User user) {
         return projectRepository.countProjectsByUser(user);
     }
-
-    /**
-     * 프로젝트 종료하기
-     *
-     * @param projectId
-     */
-    public void end(Long projectId) {
-        Project project = findById(projectId);
-        project.endProject();
-    }
 }

--- a/src/main/java/com/example/demo/service/work/WorkService.java
+++ b/src/main/java/com/example/demo/service/work/WorkService.java
@@ -26,4 +26,6 @@ public interface WorkService {
 
     // 특정 프로젝트에 할당된 특정 회원의 업무 내역 + 업무 신뢰점수 내역 조회
     PaginationResponseDto findWorksWithTrustScoreHistoryByProjectIdAndAssignedUserId(Long projectId, Long assignedUserId, Pageable pageable);
+
+    void deleteAllByProject(Project project);
 }

--- a/src/main/java/com/example/demo/service/work/WorkServiceImpl.java
+++ b/src/main/java/com/example/demo/service/work/WorkServiceImpl.java
@@ -53,4 +53,9 @@ public class WorkServiceImpl implements WorkService {
     public PaginationResponseDto findWorksWithTrustScoreHistoryByProjectIdAndAssignedUserId(Long projectId, Long assignedUserId, Pageable pageable) {
         return workRepository.findWorksWithTrustScoreHistoryByProjectIdAndAssignedUserIdOrderByStartDateDesc(projectId, assignedUserId, pageable);
     }
+
+    @Override
+    public void deleteAllByProject(Project project) {
+        workRepository.deleteAllByProject(project);
+    }
 }


### PR DESCRIPTION
### 작업내용
- 프로젝트 종료 요청 시 로직 수정
    - 요청한 회원의 userId, 요청한 projectId로 해당 프로젝트의 역할, 권한 검증(매니저)
    - 해당 프로젝트 멤버 별 사용자 프로젝트 이력 데이터에 프로젝트 완주 이력 추가
    - 해당 프로젝트의 멤버, 기술스택, 업무, 마일스톤, 알림 데이터 삭제
    - 해당 프로젝트의 status 필드를 'FINISH'로 변경
- 프로젝트 엔티티에 모든 멤버를 삭제하는 로직 추가
- 프로젝트 엔티티에 모든 기술스택을 삭제하는 로직 추가
### 연관이슈
#396 