### PR TITLE
[feature/fix-project-member-forced-withdrawal] 프로젝트 멤버 강제탈퇴 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/controller/project/ProjectMemberController.java
+++ b/src/main/java/com/example/demo/controller/project/ProjectMemberController.java
@@ -39,10 +39,11 @@ public class ProjectMemberController {
         return new ResponseEntity<>(ResponseDto.success("success"), HttpStatus.OK);
     }
 
-    @PostMapping("/{projectMemberId}/withdrawl/force")
-    public ResponseEntity<ResponseDto<?>> withdrawlForce(
+    @PostMapping("/{projectMemberId}/force-withdrawal")
+    public ResponseEntity<ResponseDto<?>> withdrawalForce(
+            @AuthenticationPrincipal PrincipalDetails user,
             @PathVariable("projectMemberId") Long projectMemberId) {
-        projectMemberService.withdrawlForce(projectMemberId);
+        projectMemberFacade.forcedWithdrawal(user.getId(), projectMemberId);
         return new ResponseEntity<>(ResponseDto.success("success"), HttpStatus.OK);
     }
 

--- a/src/main/java/com/example/demo/model/project/Project.java
+++ b/src/main/java/com/example/demo/model/project/Project.java
@@ -100,4 +100,8 @@ public class Project extends BaseTimeEntity {
     public void removeProjectTechnologies() {
         this.projectTechnologies.clear();
     }
+
+    public void removeProjectMember(ProjectMember projectMember) {
+        this.projectMembers.remove(projectMember);
+    }
 }

--- a/src/main/java/com/example/demo/service/project/ProjectMemberFacade.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberFacade.java
@@ -2,6 +2,7 @@ package com.example.demo.service.project;
 
 import com.example.demo.constant.AlertType;
 import com.example.demo.constant.ProjectMemberStatus;
+import com.example.demo.constant.ProjectRole;
 import com.example.demo.constant.UserProjectHistoryStatus;
 import com.example.demo.dto.common.PaginationResponseDto;
 import com.example.demo.dto.position.response.PositionResponseDto;
@@ -13,9 +14,11 @@ import com.example.demo.dto.user.response.UserCrewDetailResponseDto;
 import com.example.demo.dto.user.response.UserReadProjectCrewResponseDto;
 import com.example.demo.global.exception.customexception.PageNationCustomException;
 import com.example.demo.global.exception.customexception.ProjectCustomException;
+import com.example.demo.global.exception.customexception.ProjectMemberAuthCustomException;
 import com.example.demo.model.alert.Alert;
 import com.example.demo.model.project.Project;
 import com.example.demo.model.project.ProjectMember;
+import com.example.demo.model.project.ProjectMemberAuth;
 import com.example.demo.model.technology_stack.TechnologyStack;
 import com.example.demo.model.user.User;
 import com.example.demo.model.user.UserProjectHistory;
@@ -211,5 +214,35 @@ public class ProjectMemberFacade {
         PaginationResponseDto result = workService.findWorksWithTrustScoreHistoryByProjectIdAndAssignedUserId(projectMember.getProject().getId(), projectMember.getUser().getId(), PageRequest.of(pageIndex, itemCount));
 
         return result;
+    }
+
+    /**
+     * 프로젝트 멤버 강제탈퇴
+     * 사용자 프로젝트 이력에 해당 회원의 강제탈퇴 이력 추가
+     * @param projectMemberId
+     */
+    @Transactional
+    public void forcedWithdrawal(Long userId, Long projectMemberId) {
+        User currentUser = userService.findById(userId);
+        ProjectMember projectMember = projectMemberService.findById(projectMemberId);
+        Project project = projectMember.getProject();
+
+        // 프로젝트 매니저 검증
+        ProjectMemberAuth projectMemberAuth = projectMemberService.findProjectMemberByProjectAndUser(project, currentUser).getProjectMemberAuth();
+        ProjectRole projectRole = ProjectRole.findProjectRole(projectMemberAuth.getId());
+        if(!projectRole.isManager()) {
+            throw ProjectMemberAuthCustomException.INSUFFICIENT_PROJECT_AUTH;
+        }
+
+        // 사용자 프로젝트 이력에 강제탈퇴 이력 추가
+        UserProjectHistory forcedWithdrawalHistory = UserProjectHistory.builder()
+                .project(project)
+                .user(projectMember.getUser())
+                .status(UserProjectHistoryStatus.FORCED_WITHDRAWAL)
+                .build();
+        userProjectHistoryService.save(forcedWithdrawalHistory);
+
+        // 프로젝트에서 해당 멤버 삭제
+        project.removeProjectMember(projectMember);
     }
 }

--- a/src/main/java/com/example/demo/service/project/ProjectMemberService.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberService.java
@@ -31,8 +31,6 @@ public interface ProjectMemberService {
     // 프로젝트 정보, 프로젝트 멤버 상태로 멤버 목록 조회
     List<ProjectMember> getProjectMembersByProjectAndStatus(Project project, ProjectMemberStatus status);
 
-    void withdrawlForce(Long projectMemberId);
-
     ProjectMember findProjectMemberByProjectAndUser(Project project, User user);
 
     Map<String, Boolean> getUserAuthMap(Long projectId, Long userId);

--- a/src/main/java/com/example/demo/service/project/ProjectMemberServiceImpl.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberServiceImpl.java
@@ -76,16 +76,6 @@ public class ProjectMemberServiceImpl implements ProjectMemberService {
     }
 
     /**
-     * 프로젝트 멤버 강제 탈퇴하기.
-     *
-     * @param projectMemberId
-     */
-    public void withdrawlForce(Long projectMemberId) {
-        ProjectMember projectMember = findById(projectMemberId);
-        projectMemberRepository.delete(projectMember);
-    }
-
-    /**
      * 사용자의 생성 및 수정 권한 확인하기 (마일스톤, 업무)
      *
      * @param projectId


### PR DESCRIPTION
### 작업내용
- 프로젝트 멤버 강제탈퇴 요청 시 로직 수정
    - 로그인한 회원, 프로젝트 멤버의 프로젝트 정보로 요청한 회원의 프로젝트 역할, 권한 매니저 검증
    - 사용자 프로젝트 이력에 프로젝트 강제탈퇴 이력 추가
    - 해당 프로젝트에서 해당 멤버 제거
- 프로젝트 멤버 강제탈퇴 api 엔드포인트 수정
    - `/api/projectmember/{projectMemberId}/force-withdrawal`
- 프로젝트 멤버 강제탈퇴 컨트롤러 메소드명 오타 수정