### PR TITLE
[feature/fix-project-member-forced-withdrawal] 프로젝트 멤버 강제탈퇴 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/controller/project/ProjectMemberController.java
+++ b/src/main/java/com/example/demo/controller/project/ProjectMemberController.java
@@ -39,10 +39,11 @@ public class ProjectMemberController {
         return new ResponseEntity<>(ResponseDto.success("success"), HttpStatus.OK);
     }
 
-    @PostMapping("/{projectMemberId}/withdrawl/force")
-    public ResponseEntity<ResponseDto<?>> withdrawlForce(
+    @PostMapping("/{projectMemberId}/force-withdrawal")
+    public ResponseEntity<ResponseDto<?>> withdrawalForce(
+            @AuthenticationPrincipal PrincipalDetails user,
             @PathVariable("projectMemberId") Long projectMemberId) {
-        projectMemberService.withdrawlForce(projectMemberId);
+        projectMemberFacade.forcedWithdrawal(user.getId(), projectMemberId);
         return new ResponseEntity<>(ResponseDto.success("success"), HttpStatus.OK);
     }
 

--- a/src/main/java/com/example/demo/service/project/ProjectMemberFacade.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberFacade.java
@@ -114,6 +114,32 @@ public class ProjectMemberFacade {
     }
 
     /**
+     * 프로젝트 멤버 강제탈퇴
+     * 사용자 프로젝트 이력에 해당 회원의 강제탈퇴 이력 추가
+     * @param projectMemberId
+     */
+    @Transactional
+    public void forcedWithdrawal(Long userId, Long projectMemberId) {
+        User currentUser = userService.findById(userId);
+        ProjectMember projectMember = projectMemberService.findById(projectMemberId);
+        Project project = projectMember.getProject();
+
+        // 프로젝트 매니저 검증
+        projectMemberService.verifiedProjectManager(project, currentUser);
+
+        // 사용자 프로젝트 이력에 강제탈퇴 이력 추가
+        UserProjectHistory forcedWithdrawalHistory = UserProjectHistory.builder()
+                .project(project)
+                .user(projectMember.getUser())
+                .status(UserProjectHistoryStatus.FORCED_WITHDRAWAL)
+                .build();
+        userProjectHistoryService.save(forcedWithdrawalHistory);
+
+        // 프로젝트 멤버 상태 탈퇴로 변경
+        projectMember.updateStatus(ProjectMemberStatus.WITHDRAW);
+    }
+
+    /**
      * 크루정보 상세 페이지 TODO : 프로젝트 신뢰 이력 추가 해야함 유저 정보들, 유저 기술들, 프로젝트 개수, 신뢰점수 이력들
      *
      * @param projectMemberId

--- a/src/main/java/com/example/demo/service/project/ProjectMemberService.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberService.java
@@ -31,8 +31,6 @@ public interface ProjectMemberService {
     // 프로젝트 정보, 프로젝트 멤버 상태로 멤버 목록 조회
     List<ProjectMember> getProjectMembersByProjectAndStatus(Project project, ProjectMemberStatus status);
 
-    void withdrawlForce(Long projectMemberId);
-
     ProjectMember findProjectMemberByProjectAndUser(Project project, User user);
 
     Map<String, Boolean> getUserAuthMap(Long projectId, Long userId);

--- a/src/main/java/com/example/demo/service/project/ProjectMemberServiceImpl.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberServiceImpl.java
@@ -76,16 +76,6 @@ public class ProjectMemberServiceImpl implements ProjectMemberService {
     }
 
     /**
-     * 프로젝트 멤버 강제 탈퇴하기.
-     *
-     * @param projectMemberId
-     */
-    public void withdrawlForce(Long projectMemberId) {
-        ProjectMember projectMember = findById(projectMemberId);
-        projectMemberRepository.delete(projectMember);
-    }
-
-    /**
      * 사용자의 생성 및 수정 권한 확인하기 (마일스톤, 업무)
      *
      * @param projectId


### PR DESCRIPTION
### 작업내용
- 프로젝트 멤버 강제탈퇴 요청 시 로직 수정
    - 프로젝트 역할, 권한 매니저 검증
    - 사용자 프로젝트 이력에 프로젝트 강제탈퇴 이력 추가
    - 해당 프로젝트 멤버 status 필드 'WITHDRAW'로 변경
- 프로젝트 멤버 강제탈퇴 api 엔드포인트 수정
    - ` /api/projectmember/{projectMemberId}/force-withdrawal`
- 프로젝트 멤버 강제탈퇴 컨트롤러 메소드명 오타 수정