### PR TITLE
[feature/396-project-update] 프로젝트 정보 수정 로직 구현

### DIFF
--- a/src/main/java/com/example/demo/controller/project/ProjectController.java
+++ b/src/main/java/com/example/demo/controller/project/ProjectController.java
@@ -2,6 +2,7 @@ package com.example.demo.controller.project;
 
 import com.example.demo.dto.common.ResponseDto;
 import com.example.demo.dto.project.request.ProjectConfirmRequestDto;
+import com.example.demo.dto.project.request.ProjectInfoUpdateRequestDto;
 import com.example.demo.dto.project.request.ProjectParticipateRequestDto;
 import com.example.demo.dto.project.response.ProjectMeResponseDto;
 import com.example.demo.dto.project.response.ProjectSpecificDetailResponseDto;
@@ -78,5 +79,13 @@ public class ProjectController {
             @AuthenticationPrincipal PrincipalDetails user) {
         projectFacade.endProject(user.getId(), projectId);
         return new ResponseEntity<>(ResponseDto.success("success"), HttpStatus.OK);
+    }
+
+    @PutMapping("")
+    public ResponseEntity<ResponseDto<?>> updateProject(
+            @AuthenticationPrincipal PrincipalDetails user,
+            @RequestBody ProjectInfoUpdateRequestDto updateRequest) {
+        projectFacade.updateProject(user.getId(), updateRequest);
+        return new ResponseEntity<>(ResponseDto.success("프로젝트 정보 수정이 완료되었습니다."), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/demo/dto/project/request/ProjectInfoUpdateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/project/request/ProjectInfoUpdateRequestDto.java
@@ -1,0 +1,20 @@
+package com.example.demo.dto.project.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class ProjectInfoUpdateRequestDto {
+
+    @NotBlank(message = "프로젝트 ID(PK) 정보는 필수 요청 값입니다.")
+    private Long projectId;
+    private String projectName;
+    private String subject;
+    private Long trustGradeId;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/src/main/java/com/example/demo/model/project/Project.java
+++ b/src/main/java/com/example/demo/model/project/Project.java
@@ -79,6 +79,14 @@ public class Project extends BaseTimeEntity {
         this.endDate = dto.getEndDate();
     }
 
+    public void updateProject(String name, String subject, TrustGrade trustGrade, LocalDate startDate, LocalDate endDate) {
+        this.name = name;
+        this.subject = subject;
+        this.trustGrade = trustGrade;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
     public void endProject() {
         this.status = ProjectStatus.FINISH;
     }

--- a/src/main/java/com/example/demo/service/project/ProjectFacade.java
+++ b/src/main/java/com/example/demo/service/project/ProjectFacade.java
@@ -3,6 +3,7 @@ package com.example.demo.service.project;
 import com.example.demo.constant.*;
 import com.example.demo.dto.common.PaginationResponseDto;
 import com.example.demo.dto.project.request.ProjectConfirmRequestDto;
+import com.example.demo.dto.project.request.ProjectInfoUpdateRequestDto;
 import com.example.demo.dto.project.request.ProjectParticipateRequestDto;
 import com.example.demo.dto.project.response.ProjectMeResponseDto;
 import com.example.demo.dto.project.response.ProjectSpecificDetailResponseDto;
@@ -20,6 +21,7 @@ import com.example.demo.model.user.UserProjectHistory;
 import com.example.demo.service.alert.AlertService;
 import com.example.demo.service.milestone.MilestoneService;
 import com.example.demo.service.position.PositionService;
+import com.example.demo.service.trust_grade.TrustGradeService;
 import com.example.demo.service.user.UserProjectHistoryService;
 import com.example.demo.service.user.UserService;
 import com.example.demo.service.work.WorkService;
@@ -45,6 +47,7 @@ public class ProjectFacade {
     private final ProjectMemberAuthService projectMemberAuthService;
     private final MilestoneService milestoneService;
     private final UserProjectHistoryService userProjectHistoryService;
+    private final TrustGradeService trustGradeService;
 
     @Transactional(readOnly = true)
     public PaginationResponseDto getMyProjectsParticipates(Long userId, int pageIndex, int itemCount) {
@@ -252,5 +255,19 @@ public class ProjectFacade {
 
         // 프로젝트 status 종료로 변경
         project.endProject();
+    }
+
+    @Transactional
+    public void updateProject(Long userId, ProjectInfoUpdateRequestDto updateRequest) {
+        User currentUser = userService.findById(userId);
+        Project project = projectService.findById(updateRequest.getProjectId());
+
+        // 프로젝트 매니저 검증
+        projectMemberService.verifiedProjectManager(project, currentUser);
+
+        // 프로젝트 정보 수정
+        project.updateProject(updateRequest.getProjectName(), updateRequest.getSubject(),
+                trustGradeService.getTrustGradeById(updateRequest.getTrustGradeId()), updateRequest.getStartDate(),
+                        updateRequest.getEndDate());
     }
 }


### PR DESCRIPTION
### 작업내용
- 프로젝트 정보 수정 요청 로직 구현
    - 요청한 회원이 해당 프로젝트의 매니저인지 검증
    - 요청한 수정 데이터로 프로젝트 정보 수정
- 예상 요청 값
```
{
    "projectId": Long
    "projectName": "String",
    "subject": "String"
    "trustGradeId": Long, #신뢰등급 ID(1~4)
    "startDate": "yyyy-MM-dd"
    "endDate": "yyyy-MM-dd"
}
```
- 예상 응답 값
```
{
    "result": "success",
    "message": "프로젝트 정보 수정이 완료되었습니다.",
    "data": null
}
```
<br><br><br>
### 연관이슈
close #396 