### PR TITLE
feat: 참여중인 프로젝트 목록 조회 로직 수정: userId로 프로젝트 멤버 조회 -> 프로젝트 조회

### DIFF
--- a/src/main/java/com/example/demo/controller/project/ProjectController.java
+++ b/src/main/java/com/example/demo/controller/project/ProjectController.java
@@ -33,7 +33,7 @@ public class ProjectController {
             @AuthenticationPrincipal PrincipalDetails user,
             @RequestParam("pageIndex") Optional<Integer> pageIndex,
             @RequestParam("itemCount") Optional<Integer> itemCount) {
-        return new ResponseEntity<>(ResponseDto.success("success", projectFacade.getMyProjectsParticipates(user.getId(), pageIndex.orElse(0), itemCount.orElse(6))), HttpStatus.OK);
+        return new ResponseEntity<>(ResponseDto.success("success", projectFacade.getMyParticipatingProjects(user.getId(), pageIndex.orElse(0), itemCount.orElse(6))), HttpStatus.OK);
     }
 
     @GetMapping("/me")

--- a/src/main/java/com/example/demo/repository/project/ProjectMemberRepository.java
+++ b/src/main/java/com/example/demo/repository/project/ProjectMemberRepository.java
@@ -16,4 +16,7 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Lo
 
     @Query("select pm from ProjectMember pm where pm.project = :project and pm.status = :status")
     List<ProjectMember> findByProjectAndStatus(Project project, ProjectMemberStatus status);
+
+    @Query("select pm from ProjectMember pm where pm.user = :user")
+    List<ProjectMember> findByUserId(Long user);
 }

--- a/src/main/java/com/example/demo/service/project/ProjectMemberService.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberService.java
@@ -36,4 +36,6 @@ public interface ProjectMemberService {
     Map<String, Boolean> getUserAuthMap(Long projectId, Long userId);
 
     void verifiedProjectManager(Project project, User user);
+
+    List<ProjectMember> getProjectMemberByUserId(Long userId);
 }

--- a/src/main/java/com/example/demo/service/project/ProjectMemberServiceImpl.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberServiceImpl.java
@@ -112,4 +112,11 @@ public class ProjectMemberServiceImpl implements ProjectMemberService {
         Project findProject = projectService.findById(projectId);
         return findProjectMemberByProjectAndUser(findProject, findUser).getProjectMemberAuth();
     }
+
+    @Override
+    public List<ProjectMember> getProjectMemberByUserId(Long userId) {
+        return projectMemberRepository
+                .findByUserId(userId);
+    }
+
 }


### PR DESCRIPTION
참여중인 프로젝트 목록 조회 로직을 수정했습니다. 

기존에는 프로젝트 이력 테이블과 프로젝트 테이블을 매핑했는데, 프로젝트 이력이 추가 되는 방식이 바뀌면서 (status만 업데이트 -> 새로 이력 추가) 프로젝트 이력 테이블의 status값만으로는 실제로 참여중인 프로젝트만 조회할 수가 없어서 수정했습니다. 

**소면님이 기존에 작성하셨던 서비스 로직은 그대로 남겨두고, 제가 새로 만든 서비스 로직 컨트롤러단에서 호출하게 했어요.** 

jpa는 써보지 않아서 기존 코드 참고해가면서 작업한거라 동작할지는 테스트해봐야 알 것 같아요. 

코드상에 문제되는 것 없으면  배포 부탁드려요. 