### PR TITLE
[feature/fix-my-participate-projects] 내가 참여중인 프로젝트 목록 조회 버그 해결 및 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/repository/project/ProjectMemberRepository.java
+++ b/src/main/java/com/example/demo/repository/project/ProjectMemberRepository.java
@@ -15,8 +15,8 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Lo
     Optional<ProjectMember> findProjectMemberByProjectAndUser(Project project, User user);
 
     @Query("select pm from ProjectMember pm where pm.project = :project and pm.status = :status")
-    List<ProjectMember> findByProjectAndStatus(Project project, ProjectMemberStatus status);
+    List<ProjectMember> findAllByProjectAndStatus(Project project, ProjectMemberStatus status);
 
-    @Query("select pm from ProjectMember pm where pm.user = :user")
-    List<ProjectMember> findByUserId(Long user);
+    @Query("select pm from ProjectMember pm where pm.user = :user and pm.status = :status")
+    List<ProjectMember> findAllByUserAndStatus(User user, ProjectMemberStatus status);
 }

--- a/src/main/java/com/example/demo/service/project/ProjectMemberService.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberService.java
@@ -37,5 +37,5 @@ public interface ProjectMemberService {
 
     void verifiedProjectManager(Project project, User user);
 
-    List<ProjectMember> getProjectMemberByUserId(Long userId);
+    List<ProjectMember> getProjectMembersByUserAndStatus(User user, ProjectMemberStatus status);
 }

--- a/src/main/java/com/example/demo/service/project/ProjectMemberServiceImpl.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberServiceImpl.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -56,7 +57,7 @@ public class ProjectMemberServiceImpl implements ProjectMemberService {
     @Override
     public List<ProjectMember> getProjectMembersByProjectAndStatus(Project project, ProjectMemberStatus status) {
         return projectMemberRepository
-                .findByProjectAndStatus(project, status);
+                .findAllByProjectAndStatus(project, status);
     }
 
     public ProjectMember findProjectMemberByProjectAndUser(Project project, User user) {
@@ -114,9 +115,9 @@ public class ProjectMemberServiceImpl implements ProjectMemberService {
     }
 
     @Override
-    public List<ProjectMember> getProjectMemberByUserId(Long userId) {
+    public List<ProjectMember> getProjectMembersByUserAndStatus(User user, ProjectMemberStatus status) {
         return projectMemberRepository
-                .findByUserId(userId);
+                .findAllByUserAndStatus(user, status);
     }
 
 }


### PR DESCRIPTION
### 작업내용
- 기존 사용자 프로젝트 이력에서 참여중인 프로젝트 목록을 조회할 때 탈퇴, 강제탈퇴한 프로젝트 목록도 함께 조회되는 버그를 해결하고자 로직 수정
- 프로젝트 참여, 탈퇴, 강제탈퇴 시 사용자 프로젝트 이력 목록에 status 필드를 수정하지 않고 각각 이력이 추가되도록 수정함에 따라 프로젝트 멤버 목록에서 조회하도록 수정
- 프로젝트 멤버 목록 조회 쿼리의 where 조건절에서 user = : Long userId -> user = : User user로 수정
- 요청한 회원의 프로젝트 멤버 목록 중 ProjectMemberStatus 필드가 PARTICIPATING인 데이터를 조회하도록 조건 추가
- 프로젝트 List에 요청한 pageIndex, itemCount에 해당하는 데이터 목록이 존재하지 않아 `IndexOutOfBoundsException` 발생 버그 해결, Math.min() 메소드로 List의 사이즈와 비교하여 Index 초과 버그 해결