### PR TITLE
[feature/386-security-oauth2] 스프링 시큐리티 OAuth2 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ repositories {
 }
 
 dependencies {
+	/* spring security oauth */
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
 	/* null 관련 오류 방지 */
 	implementation 'com.google.code.findbugs:jsr305:3.0.2'
 

--- a/src/main/java/com/example/demo/constant/OAuthProvider.java
+++ b/src/main/java/com/example/demo/constant/OAuthProvider.java
@@ -1,0 +1,21 @@
+package com.example.demo.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum OAuthProvider {
+    KAKAO("kakao");
+
+    private final String oAuthProviderName;
+
+    public static final OAuthProvider findOAuthProvider(String oAuthProviderName) {
+        return Arrays.stream(OAuthProvider.values())
+                .filter(provider -> oAuthProviderName.toLowerCase().equals(provider.getOAuthProviderName()))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("해당 OAuth2 제공자가 존재하지 않습니다."));
+    }
+}

--- a/src/main/java/com/example/demo/dto/oauth2/response/OAuth2InfoResponseDto.java
+++ b/src/main/java/com/example/demo/dto/oauth2/response/OAuth2InfoResponseDto.java
@@ -1,0 +1,20 @@
+package com.example.demo.dto.oauth2.response;
+
+import com.example.demo.constant.OAuthProvider;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OAuth2InfoResponseDto {
+
+    private OAuthProvider provider;
+    private String providerId;
+
+    public static OAuth2InfoResponseDto of(OAuthProvider provider, String providerId) {
+        return OAuth2InfoResponseDto.builder()
+                .provider(provider)
+                .providerId(providerId)
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/global/config/SecurityConfig.java
@@ -6,6 +6,10 @@ import com.example.demo.security.custom.UserAuthenticationFailureHandler;
 import com.example.demo.security.custom.UserAuthenticationFilter;
 import com.example.demo.security.custom.UserAuthenticationSuccessHandler;
 import com.example.demo.security.jwt.*;
+import com.example.demo.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
+import com.example.demo.security.oauth2.handler.OAuth2AuthenticationFailureHandler;
+import com.example.demo.security.oauth2.handler.OAuth2AuthenticationSuccessHandler;
+import com.example.demo.security.oauth2.service.OAuth2PrincipalService;
 import com.example.demo.service.token.RefreshTokenRedisService;
 import com.example.demo.service.user.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,6 +42,10 @@ public class SecurityConfig {
     private final SecurityResponseHandler securityResponseHandler;
     private final RefreshTokenRedisService refreshTokenRedisService;
     private final UserService userService;
+    private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+    private final OAuth2PrincipalService OAuth2PrincipalService;
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+    private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -87,7 +95,7 @@ public class SecurityConfig {
                 .authorizeRequests()
                 .antMatchers("/api/admin/**")
                 .hasRole("ADMIN")
-                .antMatchers("/**/public")
+                .antMatchers("/**/public", "/oauth2/**")
                 .permitAll()
                 .anyRequest()
                 .authenticated()
@@ -113,6 +121,12 @@ public class SecurityConfig {
                         jsonWebTokenProvider,
                         securityResponseHandler),
                 JsonWebTokenExceptionFilter.class);
+
+        http.oauth2Login(configure ->
+                configure.authorizationEndpoint(config -> config.authorizationRequestRepository(httpCookieOAuth2AuthorizationRequestRepository))
+                        .userInfoEndpoint(config -> config.userService(OAuth2PrincipalService))
+                        .successHandler(oAuth2AuthenticationSuccessHandler)
+                        .failureHandler(oAuth2AuthenticationFailureHandler));
 
         return http.build();
     }

--- a/src/main/java/com/example/demo/global/exception/customexception/OAuth2CustomException.java
+++ b/src/main/java/com/example/demo/global/exception/customexception/OAuth2CustomException.java
@@ -1,0 +1,13 @@
+package com.example.demo.global.exception.customexception;
+
+import com.example.demo.global.exception.errorcode.OAuth2ErrorCode;
+
+public class OAuth2CustomException extends CustomException{
+
+    public static final OAuth2CustomException NOT_FOUND_OAUTH_PRINCIPAL =
+            new OAuth2CustomException(OAuth2ErrorCode.NOT_FOUND_OAUTH_PRINCIPAL);
+
+    public OAuth2CustomException(OAuth2ErrorCode oAuth2ErrorCode) {
+        super(oAuth2ErrorCode);
+    }
+}

--- a/src/main/java/com/example/demo/global/exception/errorcode/OAuth2ErrorCode.java
+++ b/src/main/java/com/example/demo/global/exception/errorcode/OAuth2ErrorCode.java
@@ -1,0 +1,23 @@
+package com.example.demo.global.exception.errorcode;
+
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum OAuth2ErrorCode implements ErrorCode{
+
+    NOT_FOUND_OAUTH_PRINCIPAL(HttpStatus.NOT_FOUND, "OAuth 인증 정보를 찾을 수 없습니다.");
+
+    private HttpStatus status;
+    private String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return this.status;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/example/demo/global/util/CookieUtils.java
+++ b/src/main/java/com/example/demo/global/util/CookieUtils.java
@@ -1,0 +1,55 @@
+package com.example.demo.global.util;
+
+import org.springframework.util.SerializationUtils;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Base64;
+import java.util.Optional;
+
+public class CookieUtils {
+
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if(cookies != null) {
+            for(Cookie cookie : cookies) {
+                if(cookie.getName().equals(name)) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        if(cookies != null) {
+            for(Cookie cookie : cookies) {
+                if(cookie.getName().equals(name)) {
+                    cookie.setValue("");
+                    cookie.setPath("/");
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                }
+            }
+        }
+    }
+
+    public static String serialize(Object object) {
+        return Base64.getUrlEncoder()
+                .encodeToString(SerializationUtils.serialize(object));
+    }
+
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        return cls.cast(SerializationUtils.deserialize(
+                Base64.getUrlDecoder().decode(cookie.getValue())));
+    }
+}

--- a/src/main/java/com/example/demo/model/user/User.java
+++ b/src/main/java/com/example/demo/model/user/User.java
@@ -1,5 +1,6 @@
 package com.example.demo.model.user;
 
+import com.example.demo.constant.OAuthProvider;
 import com.example.demo.constant.Role;
 import com.example.demo.constant.UserStatus;
 import com.example.demo.global.common.BaseTimeEntity;
@@ -48,6 +49,13 @@ public class User extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private UserStatus status;
 
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "oauth_provider")
+    private OAuthProvider oAuthProvider;
+
+    @Column(name = "oauth_provider_id")
+    private String oAuthProviderId;
+
     @Builder
     private User(
             String email,
@@ -57,7 +65,9 @@ public class User extends BaseTimeEntity {
             String intro,
             Position position,
             Role role,
-            UserStatus status) {
+            UserStatus status,
+            OAuthProvider oAuthProvider,
+            String oAuthProviderId) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
@@ -66,6 +76,8 @@ public class User extends BaseTimeEntity {
         this.position = position;
         this.role = role;
         this.status = status;
+        this.oAuthProvider = oAuthProvider;
+        this.oAuthProviderId = oAuthProviderId;
     }
 
     // 기술스택 목록 등록

--- a/src/main/java/com/example/demo/repository/user/UserRepository.java
+++ b/src/main/java/com/example/demo/repository/user/UserRepository.java
@@ -1,8 +1,10 @@
 package com.example.demo.repository.user;
 
+import com.example.demo.constant.OAuthProvider;
 import com.example.demo.model.user.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
 
@@ -14,4 +16,8 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
 
     // 이메일로 회원 조화
     Optional<User> findByEmail(String email);
+
+    // provider, provider_id로 회원조회
+    @Query(value = "select u from User u where u.oAuthProvider = :provider and u.oAuthProviderId = :providerId")
+    Optional<User> findByProviderAndProviderId(OAuthProvider provider, String providerId);
 }

--- a/src/main/java/com/example/demo/security/jwt/JsonWebTokenProvider.java
+++ b/src/main/java/com/example/demo/security/jwt/JsonWebTokenProvider.java
@@ -19,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -60,14 +61,14 @@ public class JsonWebTokenProvider {
     }
 
     // 토큰 발급 (Access Token & Refresh Token 함께 발급)
-    public JsonWebTokenDto generateToken(PrincipalDetails principalDetails) {
+    public JsonWebTokenDto generateToken(UserDetails principal) {
 
         // Access Token 생성
         Date accessTokenExpiresIn = getTokenExpiration(accessTokenExpirationMillis);
 
-        Claims claims = Jwts.claims().setSubject(principalDetails.getUsername());
-        claims.put("email", principalDetails.getEmail());
-        claims.put("role", principalDetails.getAuthorities());
+        Claims claims = Jwts.claims().setSubject(principal.getUsername());
+        //claims.put("email", principalDetails.getEmail());
+        claims.put("role", principal.getAuthorities());
 
         String accessToken =
                 Jwts.builder()

--- a/src/main/java/com/example/demo/security/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/example/demo/security/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,70 @@
+package com.example.demo.security.oauth2;
+
+import com.example.demo.global.util.CookieUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@RequiredArgsConstructor
+@Component
+public class HttpCookieOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+    public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+    public static final String MODE_PARAM_COOKIE_NAME = "mode";
+    private static final int COOKIE_EXPIRE_SECONDS = 180;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        return CookieUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+                .map(cookie -> CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class))
+                .orElse(null);
+
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+        if(authorizationRequest == null) {
+            CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+            CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+            CookieUtils.deleteCookie(request, response, MODE_PARAM_COOKIE_NAME);
+            return;
+        }
+
+        CookieUtils.addCookie(response,
+                OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+                CookieUtils.serialize(authorizationRequest),
+                COOKIE_EXPIRE_SECONDS);
+
+        String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+        if(StringUtils.hasText(redirectUriAfterLogin)) {
+            CookieUtils.addCookie(response,
+                    REDIRECT_URI_PARAM_COOKIE_NAME,
+                    redirectUriAfterLogin,
+                    COOKIE_EXPIRE_SECONDS);
+        }
+
+        String mode = request.getParameter(MODE_PARAM_COOKIE_NAME);
+        if(StringUtils.hasText(mode)) {
+            CookieUtils.addCookie(response,
+                    MODE_PARAM_COOKIE_NAME,
+                    mode,
+                    COOKIE_EXPIRE_SECONDS);
+        }
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request) {
+        return this.loadAuthorizationRequest(request);
+    }
+
+    public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+        CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+        CookieUtils.deleteCookie(request, response, MODE_PARAM_COOKIE_NAME);
+    }
+}

--- a/src/main/java/com/example/demo/security/oauth2/handler/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/example/demo/security/oauth2/handler/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,34 @@
+package com.example.demo.security.oauth2.handler;
+
+import com.example.demo.dto.common.ResponseDto;
+import com.example.demo.global.util.CookieUtils;
+import com.example.demo.security.SecurityResponseHandler;
+import com.example.demo.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static com.example.demo.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
+
+@RequiredArgsConstructor
+@Component
+public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+    private final SecurityResponseHandler securityResponseHandler;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
+        httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+
+        securityResponseHandler.sendResponse(response, HttpStatus.UNAUTHORIZED, ResponseDto.fail("소셜 회원 인증에 실패하였습니다."));
+    }
+}

--- a/src/main/java/com/example/demo/security/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/demo/security/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,77 @@
+package com.example.demo.security.oauth2.handler;
+
+import com.example.demo.dto.common.ResponseDto;
+import com.example.demo.dto.oauth2.response.OAuth2InfoResponseDto;
+import com.example.demo.global.exception.customexception.OAuth2CustomException;
+import com.example.demo.global.util.CookieUtils;
+import com.example.demo.security.SecurityResponseHandler;
+import com.example.demo.security.jwt.JsonWebTokenDto;
+import com.example.demo.security.jwt.JsonWebTokenProvider;
+import com.example.demo.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
+import com.example.demo.security.oauth2.service.OAuth2PrincipalDetails;
+import com.example.demo.service.token.RefreshTokenRedisService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private static final int REFRESH_COOKIE_MAX_AGE = 7 * 24 * 60 * 60;
+    private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+    private final RefreshTokenRedisService refreshTokenRedisService;
+    private final JsonWebTokenProvider jsonWebTokenProvider;
+    private final SecurityResponseHandler securityResponseHandler;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+        OAuth2PrincipalDetails oAuthPrincipal = getOAuth2UserPrincipal(authentication);
+        clearAuthenticationAttributes(request, response);
+
+        if(oAuthPrincipal == null) {
+            throw OAuth2CustomException.NOT_FOUND_OAUTH_PRINCIPAL;
+        }
+
+        // 가입되지 않은 회원일 경우
+        if(oAuthPrincipal.getId() == null) {
+            OAuth2InfoResponseDto infoResponse = OAuth2InfoResponseDto.of(oAuthPrincipal.getOAuth2Provider(), oAuthPrincipal.getOAuth2ProviderId());
+
+            securityResponseHandler
+                    .sendResponse(response, HttpStatus.OK, ResponseDto.success("가입되지 않은 소셜 회원입니다. 가입을 진행해주세요.", infoResponse));
+            return;
+        }
+
+        // 토큰 발급
+        JsonWebTokenDto tokens = jsonWebTokenProvider.generateToken(oAuthPrincipal);
+        refreshTokenRedisService.save(oAuthPrincipal.getId(), tokens.getRefreshToken());
+
+        // 토큰 셋팅
+        response.setHeader("Authorization", tokens.getAccessToken());
+        CookieUtils.addCookie(response, "Refresh", tokens.getRefreshToken(), REFRESH_COOKIE_MAX_AGE);
+
+        securityResponseHandler.sendResponse(response, HttpStatus.OK, ResponseDto.success("소셜 로그인에 성공하였습니다."));
+    }
+
+    private OAuth2PrincipalDetails getOAuth2UserPrincipal(Authentication authentication) {
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof OAuth2PrincipalDetails) {
+            return (OAuth2PrincipalDetails) principal;
+        }
+        return null;
+    }
+
+    protected void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
+        super.clearAuthenticationAttributes(request);
+        httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+    }
+}

--- a/src/main/java/com/example/demo/security/oauth2/service/OAuth2PrincipalDetails.java
+++ b/src/main/java/com/example/demo/security/oauth2/service/OAuth2PrincipalDetails.java
@@ -1,0 +1,85 @@
+package com.example.demo.security.oauth2.service;
+
+import com.example.demo.constant.OAuthProvider;
+import com.example.demo.constant.Role;
+import com.example.demo.security.oauth2.user.OAuth2UserInfo;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+@Getter
+public class OAuth2PrincipalDetails implements OAuth2User, UserDetails {
+
+    private final Long id;
+    private final Role role;
+    private final OAuth2UserInfo userInfo;
+
+    public OAuth2PrincipalDetails(Long id, Role role, OAuth2UserInfo userInfo) {
+        this.id = id;
+        this.role = role;
+        this.userInfo = userInfo;
+    }
+
+    public OAuth2PrincipalDetails(OAuth2UserInfo userInfo) {
+        this.id = null;
+        this.role = null;
+        this.userInfo = userInfo;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return String.valueOf(this.id);
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority("ROLE_" + this.role));
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    public String getOAuth2ProviderId() { return this.userInfo.getProviderId(); }
+
+    public OAuthProvider getOAuth2Provider() {
+        return this.userInfo.getProvider();
+    }
+}

--- a/src/main/java/com/example/demo/security/oauth2/service/OAuth2PrincipalService.java
+++ b/src/main/java/com/example/demo/security/oauth2/service/OAuth2PrincipalService.java
@@ -1,0 +1,51 @@
+package com.example.demo.security.oauth2.service;
+
+import com.example.demo.constant.OAuthProvider;
+import com.example.demo.constant.UserStatus;
+import com.example.demo.model.user.User;
+import com.example.demo.repository.user.UserRepository;
+import com.example.demo.security.oauth2.user.OAuth2UserInfo;
+import com.example.demo.security.oauth2.user.OAuth2UserInfoFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OAuth2PrincipalService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String oAuth2ProviderId = oAuth2User.getName();
+        log.info("OAuth 제공자: {}", registrationId);
+        log.info("OAuth 고유번호: {}", oAuth2ProviderId);
+
+        User user = userRepository
+                .findByProviderAndProviderId(OAuthProvider.findOAuthProvider(registrationId), oAuth2ProviderId)
+                .orElse(null);
+
+        OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(
+                registrationId,
+                oAuth2ProviderId);
+
+        return processOAuth2User(user, oAuth2UserInfo);
+    }
+
+    private OAuth2User processOAuth2User(User user, OAuth2UserInfo oAuth2UserInfo) {
+        if(user == null || user.getStatus().equals(UserStatus.DELETED)) {
+            return new OAuth2PrincipalDetails(oAuth2UserInfo);
+        }
+
+        return new OAuth2PrincipalDetails(user.getId(), user.getRole(), oAuth2UserInfo);
+    }
+}

--- a/src/main/java/com/example/demo/security/oauth2/user/OAuth2UserInfo.java
+++ b/src/main/java/com/example/demo/security/oauth2/user/OAuth2UserInfo.java
@@ -1,0 +1,16 @@
+package com.example.demo.security.oauth2.user;
+
+import com.example.demo.constant.OAuthProvider;
+
+import java.util.Map;
+
+/**
+ * OAuth2 사용자 정보 데이터 구조,
+ * 각 제공자 별 사용자 정보 데이터가 다름
+ */
+public interface OAuth2UserInfo {
+
+    OAuthProvider getProvider();
+
+    String getProviderId();
+}

--- a/src/main/java/com/example/demo/security/oauth2/user/OAuth2UserInfoFactory.java
+++ b/src/main/java/com/example/demo/security/oauth2/user/OAuth2UserInfoFactory.java
@@ -1,0 +1,13 @@
+package com.example.demo.security.oauth2.user;
+
+/**
+ * OAuth2 인증 시 엑세스 토큰으로 사용자 정보를 가져왔을 때,
+ * OAuth2 제공자 별로 OAuth2UserInfo 객체를 생성해주는 팩토리
+ */
+public class OAuth2UserInfoFactory {
+
+    public static OAuth2UserInfo getOAuth2UserInfo(String oAuthProviderName,
+                                                   String oAuthProviderId) {
+        return null;
+    }
+}


### PR DESCRIPTION
### 작업내용
- OAuth 회원을 구분하기 위한 User 엔티티에  oAuthProvider, oAuthProviderId 필드 추가
- 소셜 로그인을 위한 스프링 시큐리티 OAuth2 적용
    - `OAuthProvider` : OAuth 제공자를 enum으로 관리하기 위한 클래스
    - `OAuth2UserInfo` : OAuth2 서버로부터 제공 받은 사용자 정보를 관리하기 위한 인터페이스
    - `OAuth2UserInfoFactory` : 각 OAuth2 제공자 별로 OAuth2UserInfo 객체를 생성하기 위한 클래스
    - `OAuth2PrincipalDetails` : 스프링 시큐리티의 OAuth2User, UserDetails를 구현한 커스텀 OAuth2 인증 객체
    - `OAuth2PrincipalService` : 엑세스 토큰을 OAuth2 제공자로부터 제공 받았을 때 실행하는 서비스 클래스, 스프링 시큐리티의 DefaultOAuth2UserService 클래스를 상속받아 OAuth2 인증 과정을 수행하고 해당 소셜 회원의 서비스 등록 여부에 따라 다른 인증 객체를 반환
    - `OAuth2AuthenticationSuccessHandler`/`OAuth2AuthenticationFailureHandler` : OAuth2 인증 과정에 성공 및 실패 시 실행되는 핸들러, 성공 시 서비스에 가입되지 않은 회원인 경우 OAuth 제공자 정보와 OAuth 고유번호를 응답하고 가입된 회원인 경우 서비스 자체 JWT 발급
    - `HttpCookieOAuth2AuthorizationRequestRepository` : OAuth2 인증 과정 중 필요한 데이터를 쿠키로 관리해 인가 요청하기 위한 사용자 정의 클래스
- OAuth2 커스텀 예외 및 에러코드 추가
- 쿠키 조회, 추가, 삭제 로직을 수행하는 CookieUtils 클래스 추가<br><br><br>
### 연관이슈
#386 