### PR TITLE
[feature/386-oauth-kakao] OAuth 카카오 추가

### DIFF
--- a/src/main/java/com/example/demo/security/oauth2/user/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/example/demo/security/oauth2/user/KakaoOAuth2UserInfo.java
@@ -1,0 +1,24 @@
+package com.example.demo.security.oauth2.user;
+
+import com.example.demo.constant.OAuthProvider;
+
+/**
+ * 카카오 사용자 정보
+ */
+public class KakaoOAuth2UserInfo implements OAuth2UserInfo{
+    private final String kakaoProviderId;
+
+    public KakaoOAuth2UserInfo(String oAuthProviderId) {
+        this.kakaoProviderId = oAuthProviderId;
+    }
+
+    @Override
+    public OAuthProvider getProvider() {
+        return OAuthProvider.KAKAO;
+    }
+
+    @Override
+    public String getProviderId() {
+        return this.kakaoProviderId;
+    }
+}

--- a/src/main/java/com/example/demo/security/oauth2/user/OAuth2UserInfoFactory.java
+++ b/src/main/java/com/example/demo/security/oauth2/user/OAuth2UserInfoFactory.java
@@ -1,5 +1,7 @@
 package com.example.demo.security.oauth2.user;
 
+import com.example.demo.constant.OAuthProvider;
+
 /**
  * OAuth2 인증 시 엑세스 토큰으로 사용자 정보를 가져왔을 때,
  * OAuth2 제공자 별로 OAuth2UserInfo 객체를 생성해주는 팩토리
@@ -8,6 +10,11 @@ public class OAuth2UserInfoFactory {
 
     public static OAuth2UserInfo getOAuth2UserInfo(String oAuthProviderName,
                                                    String oAuthProviderId) {
+
+        // 카카오
+        if(OAuthProvider.KAKAO.getOAuthProviderName().equals(oAuthProviderName)) {
+            return new KakaoOAuth2UserInfo(oAuthProviderId);
+        }
         return null;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -60,5 +60,16 @@ cloud.aws.credentials.secret-key=${S3_SECRET_KEY}
 spring.servlet.multipart.max-file-size=5MB
 spring.servlet.multipart.max-request-size=5MB
 
+# Spring Security OAuth2 kakao
+spring.security.oauth2.client.registration.kakao.client-id=${KAKAO_CLIENT_ID}
+spring.security.oauth2.client.registration.kakao.client-secret=${KAKAO_CLIENT_SECRET}
+spring.security.oauth2.client.registration.kakao.client-authentication-method=client_secret_post
+spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.kakao.redirect-uri={baseUrl}/{action}/oauth2/code/{registrationId}
+spring.security.oauth2.client.registration.kakao.client-name=Kakao
 
-
+spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
+spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
+spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
+spring.security.oauth2.client.provider.kakao.user-info-authentication-method=header
+spring.security.oauth2.client.provider.kakao.user-name-attribute=id


### PR DESCRIPTION
### 작업내용
- 카카오 서버로부터 제공 받은 사용자 정보를 관리하는 클래스 KakaoOAuth2UserInfo 클래스 추가
- 요청한 OAuth2 제공자별 OAuth2UserInfo 객체를 반환하는 로직에 카카오 추가
- 시큐리티 OAuth2 카카오 설정 추가<br><br><br>
### 연관이슈
#386 