### PR TITLE
[feature/413-participate-project-members] 참여중인 프로젝트 목록 조회 시 특정 프로젝트 멤버 데이터 응답 수정

### DIFF
--- a/src/main/java/com/example/demo/service/project/ProjectFacade.java
+++ b/src/main/java/com/example/demo/service/project/ProjectFacade.java
@@ -78,6 +78,7 @@ public class ProjectFacade {
         List<ProjectMeResponseDto> content = new ArrayList<>();
         for (Project project : slicedProjects) {
             List<MyProjectMemberResponseDto> myProjectMembers = project.getProjectMembers().stream()
+                    .filter(projectMember -> projectMember.getStatus().equals(ProjectMemberStatus.PARTICIPATING))
                     .map(projectMember -> MyProjectMemberResponseDto.of(projectMember, UserMyProjectResponseDto.of(projectMember.getUser())))
                     .collect(Collectors.toList());
 


### PR DESCRIPTION
### 작업내용
- 기존 참여중인 프로젝트 목록 조회 로직에서 특정 프로젝트의 멤버 목록 중 탈퇴, 강제탈퇴한 멤버도 함께 응답되는 버그 해결
- 특정 프로젝트의 멤버정보를 응답 DTO로 변환하는 로직에서 filter() 메소드를 활용해 참여중인 멤버들만 응답되도록 수정<br><br><br>
### 연관이슈
close #413 