### PR TITLE
[feature/415-fix-board-search] 게시글 목록 검색 조회 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/repository/board/BoardRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/board/BoardRepositoryCustom.java
@@ -2,11 +2,12 @@ package com.example.demo.repository.board;
 
 import java.util.List;
 
+import com.example.demo.constant.ProjectStatus;
 import com.example.demo.dto.common.PaginationResponseDto;
 import org.springframework.data.domain.Pageable;
 
 public interface BoardRepositoryCustom {
 
     PaginationResponseDto getBoardSearchPage(
-            Long positionId, String keyword, List<Long> technologyIds, Pageable pageable);
+            Long positionId, String keyword, List<Long> technologyIds, Boolean recruitmentStatus, ProjectStatus status, Pageable pageable);
 }

--- a/src/main/java/com/example/demo/service/board/BoardServiceImpl.java
+++ b/src/main/java/com/example/demo/service/board/BoardServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.demo.service.board;
 
+import com.example.demo.constant.ProjectStatus;
 import com.example.demo.dto.board.response.BoardDetailResponseDto;
 import com.example.demo.dto.board.response.BoardTotalDetailResponseDto;
 import com.example.demo.dto.boardposition.BoardPositionDetailResponseDto;
@@ -37,7 +38,7 @@ public class BoardServiceImpl implements BoardService {
     @Transactional(readOnly = true)
     public PaginationResponseDto search(
             Long positionId, String keyword, List<Long> technologyIds, Pageable pageable) {
-        return boardRepository.getBoardSearchPage(positionId, keyword, technologyIds, pageable);
+        return boardRepository.getBoardSearchPage(positionId, keyword, technologyIds, false, ProjectStatus.FINISH, pageable);
     }
 
     public Board findById(Long boardId) {


### PR DESCRIPTION
### 작업내용
- 기존 게시글 목록 검색 조회 시 모집이 만료된 게시글 및 게시글의 프로젝트가 종료된 목록까지 함께 조회되는 버그 해결
- 게시글 목록 검색 조회 시 특정 게시글의 모집상태(recruitmentStatus) 값이 false(모집중)이고 게시글의 프로젝트 상태 값(projectStatus)이 'FINISH'가 아닌 게시글 목록만을 조회하도록 수정
<br><br><br>
### 연관이슈
close #415 