### PR TITLE
[feature/417-fix-work] 프로젝트 업무 관련 수정

### DIFF
--- a/src/main/java/com/example/demo/controller/work/WorkController.java
+++ b/src/main/java/com/example/demo/controller/work/WorkController.java
@@ -15,6 +15,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+
 @RestController
 @RequiredArgsConstructor
 public class WorkController {
@@ -27,7 +29,7 @@ public class WorkController {
             @AuthenticationPrincipal PrincipalDetails user,
             @PathVariable("projectId") Long projectId,
             @PathVariable("milestoneId") Long milestoneId,
-            @RequestBody WorkCreateRequestDto workCreateRequestDto) {
+            @Valid @RequestBody WorkCreateRequestDto workCreateRequestDto) {
         workFacade.create(user.getId(), projectId, milestoneId, workCreateRequestDto);
         return new ResponseEntity<>(ResponseDto.success("success"), HttpStatus.OK);
     }

--- a/src/main/java/com/example/demo/dto/projectmember/response/ProjectMemberWorkWithTrustScoreResponseDto.java
+++ b/src/main/java/com/example/demo/dto/projectmember/response/ProjectMemberWorkWithTrustScoreResponseDto.java
@@ -11,6 +11,7 @@ public class ProjectMemberWorkWithTrustScoreResponseDto {
 
     private Long workId;
     private String workContent;
+    private String workContentDetail;
     private LocalDate startDate;
     private LocalDate endDate;
     private String progressStatus;
@@ -18,10 +19,11 @@ public class ProjectMemberWorkWithTrustScoreResponseDto {
     private Integer point;
     private String point_type;
 
-    public ProjectMemberWorkWithTrustScoreResponseDto(Long workId, String workContent, LocalDate startDate,
+    public ProjectMemberWorkWithTrustScoreResponseDto(Long workId, String workContent, String workContentDetail, LocalDate startDate,
                                                       LocalDate endDate, ProgressStatus progressStatus, Long trustScoreHistoryId, Integer point) {
         this.workId = workId;
         this.workContent = workContent;
+        this.workContentDetail = workContentDetail;
         this.startDate = startDate;
         this.endDate = endDate;
         this.progressStatus = progressStatus.getDescription();

--- a/src/main/java/com/example/demo/dto/work/request/WorkCreateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/work/request/WorkCreateRequestDto.java
@@ -10,12 +10,25 @@ import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
 @Getter
 @AllArgsConstructor
 public class WorkCreateRequestDto {
+    @NotBlank(message = "업무 내용은 필수 요청 값입니다.")
     private String content;
+
+    @NotBlank(message = "업무 상세 내용은 필수 요청 값입니다.")
+    private String contentDetail;
+
+    @NotNull(message = "업무 시작 날짜는 필수 요청 값입니다.")
     private LocalDate startDate;
+
+    @NotNull(message = "업무 종료 날짜는 필수 요청 값입니다.")
     private LocalDate endDate;
+
+    @NotNull(message = "업무 할당자는 필수 요청 값입니다.")
     private Long assignedUserId;
 
     public Work toWorkEntity(
@@ -26,6 +39,7 @@ public class WorkCreateRequestDto {
                 .assignedUserId(user)
                 .lastModifiedMember(projectMember)
                 .content(this.getContent())
+                .contentDetail(this.getContentDetail())
                 .progressStatus(ProgressStatus.BEFORE_START)
                 .startDate(this.getStartDate())
                 .endDate(this.getEndDate())

--- a/src/main/java/com/example/demo/dto/work/request/WorkUpdateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/work/request/WorkUpdateRequestDto.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class WorkUpdateRequestDto {
     private String content;
+    private String contentDetail;
     private LocalDate startDate;
     private LocalDate endDate;
     private String progressStatusCode;

--- a/src/main/java/com/example/demo/dto/work/response/WorkProjectDetailResponseDto.java
+++ b/src/main/java/com/example/demo/dto/work/response/WorkProjectDetailResponseDto.java
@@ -17,6 +17,7 @@ public class WorkProjectDetailResponseDto {
     private UserProjectDetailResponseDto assginedUser;
     private ProjectMember lastModifiedMember;
     private String workContent;
+    private String workContentDetail;
     private String progressStatus;
     private LocalDate startDate;
     private LocalDate endDate;
@@ -34,6 +35,7 @@ public class WorkProjectDetailResponseDto {
                 .assginedUser(userProjectDetailResponseDto)
                 .lastModifiedMember(work.getLastModifiedMember())
                 .workContent(work.getContent())
+                .workContentDetail(work.getContentDetail())
                 .progressStatus(work.getProgressStatus().getDescription())
                 .startDate(work.getStartDate())
                 .endDate(work.getEndDate())

--- a/src/main/java/com/example/demo/dto/work/response/WorkReadResponseDto.java
+++ b/src/main/java/com/example/demo/dto/work/response/WorkReadResponseDto.java
@@ -20,18 +20,20 @@ public class WorkReadResponseDto {
     private WorkAssignedUserInfoResponseDto assignedUser;
     private String lastModifiedMemberNickname;
     private String content;
+    private String contentDetail;
     private LocalDate startDate;
     private LocalDate endDate;
     private String progressStatus;
 
     public WorkReadResponseDto(Long workId, Long projectId, Long milestoneId, WorkAssignedUserInfoResponseDto assignedUser, String lastModifiedMemberNickname,
-                               String content, LocalDate startDate, LocalDate endDate, ProgressStatus progressStatus) {
+                               String content, String contentDetail, LocalDate startDate, LocalDate endDate, ProgressStatus progressStatus) {
         this.workId = workId;
         this.projectId = projectId;
         this.milestoneId = milestoneId;
         this.assignedUser = assignedUser;
         this.lastModifiedMemberNickname = lastModifiedMemberNickname;
         this.content = content;
+        this.contentDetail = contentDetail;
         this.startDate = startDate;
         this.endDate = endDate;
         this.progressStatus = progressStatus.getDescription();
@@ -45,6 +47,7 @@ public class WorkReadResponseDto {
                 .assignedUser(WorkAssignedUserInfoResponseDto.of(projectMember.getId(), assignedUser.getNickname()))
                 .lastModifiedMemberNickname(work.getLastModifiedMember().getUser().getNickname())
                 .content(work.getContent())
+                .contentDetail(work.getContentDetail())
                 .startDate(work.getStartDate())
                 .endDate(work.getEndDate())
                 .progressStatus(work.getProgressStatus().getDescription())

--- a/src/main/java/com/example/demo/model/work/Work.java
+++ b/src/main/java/com/example/demo/model/work/Work.java
@@ -44,6 +44,9 @@ public class Work extends BaseTimeEntity {
     @Column(name = "work_content")
     private String content;
 
+    @Column(name = "content_detail", columnDefinition = "TEXT")
+    private String contentDetail;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "progressStatus")
     private ProgressStatus progressStatus;
@@ -67,6 +70,7 @@ public class Work extends BaseTimeEntity {
             Milestone milestone,
             User assignedUserId,
             String content,
+            String contentDetail,
             ProgressStatus progressStatus,
             LocalDate startDate,
             LocalDate endDate,
@@ -75,6 +79,7 @@ public class Work extends BaseTimeEntity {
         this.milestone = milestone;
         this.assignedUserId = assignedUserId;
         this.content = content;
+        this.contentDetail = contentDetail;
         this.progressStatus = progressStatus;
         this.startDate = startDate;
         this.endDate = endDate;
@@ -84,6 +89,7 @@ public class Work extends BaseTimeEntity {
 
     public void update(WorkUpdateRequestDto dto, ProjectMember projectMember, User assignedUser) {
         this.content = dto.getContent();
+        this.contentDetail = dto.getContentDetail();
         this.startDate = dto.getStartDate();
         this.endDate = dto.getEndDate();
         this.progressStatus = ProgressStatus.getProgressStatusByCode(dto.getProgressStatusCode());

--- a/src/main/java/com/example/demo/repository/work/WorkRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/work/WorkRepositoryImpl.java
@@ -56,6 +56,7 @@ public class WorkRepositoryImpl implements WorkRepositoryCustom{
                                 ),
                                 qLastModifiedProjectMember.user.nickname,
                                 qWork.content,
+                                qWork.contentDetail,
                                 qWork.startDate,
                                 qWork.endDate,
                                 qWork.progressStatus
@@ -90,6 +91,7 @@ public class WorkRepositoryImpl implements WorkRepositoryCustom{
                                 ProjectMemberWorkWithTrustScoreResponseDto.class,
                                 qWork.id,
                                 qWork.content,
+                                qWork.contentDetail,
                                 qWork.startDate,
                                 qWork.endDate,
                                 qWork.progressStatus,


### PR DESCRIPTION
### 작업내용
- Work 엔티티에 업무 상세내용 contentDetail 필드 추가
- 업무 관련 로직 수행 시 새로 추가한 contentDetail 필드 요청, 응답 추가
    - `WorkCreateRequestDto` : 업무 생성 요청 데이터에 contentDetail 값 추가
    - `WorkUpdateRequestDto` : 업무 수정 요청 데이터에 contentDetail 값 추가
    - `WorkReadResponseDto`, `WorkProjectDetailResponseDto`, `ProjectMemberWorkWithTrustScoreResponseDto` : 업무 관련 응답 데이터에 contentDetail 값 추가
- 업무 목록 관련 조회 쿼리에서 Work 엔티티의 contentDetail 값을 셋팅하도록 수정<br><br><br>
### 연관이슈
close #417 