### PR TITLE
[feature/386-oauth-signup] OAuth 소셜 회원가입 로직 구현

### DIFF
--- a/src/main/java/com/example/demo/controller/user/UserController.java
+++ b/src/main/java/com/example/demo/controller/user/UserController.java
@@ -1,6 +1,7 @@
 package com.example.demo.controller.user;
 
 import com.example.demo.dto.common.ResponseDto;
+import com.example.demo.dto.oauth2.request.OAuth2UserCreateRequestDto;
 import com.example.demo.dto.user.request.UserCreateRequestDto;
 import com.example.demo.dto.user.request.UserUpdateRequestDto;
 import com.example.demo.security.custom.PrincipalDetails;
@@ -51,6 +52,14 @@ public class UserController {
             @Valid @RequestBody UserCreateRequestDto createRequest) {
         return ResponseEntity.status(HttpStatus.CREATED).body(userFacade.createUser(createRequest));
     }
+
+    // 소셜 회원가입
+    @PostMapping("/oauth2/public")
+    public ResponseEntity<ResponseDto<?>> oAuthSignup(
+            @Valid @RequestBody OAuth2UserCreateRequestDto oAuthUserCreateRequest) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(userFacade.createOAuthUser(oAuthUserCreateRequest));
+    }
+
 
     // 회원수정
     @PutMapping()

--- a/src/main/java/com/example/demo/dto/oauth2/request/OAuth2UserCreateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/oauth2/request/OAuth2UserCreateRequestDto.java
@@ -1,0 +1,33 @@
+package com.example.demo.dto.oauth2.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class OAuth2UserCreateRequestDto {
+
+    @NotBlank(message = "OAuth 제공자 정보는 필수 요청 값입니다.")
+    private String oAuthProvider;
+
+    @NotBlank(message = "OAuth 제공자 고유 번호는 필수 요청 값입니다.")
+    private String oAuthProviderId;
+
+    @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9]{6,10}$", message = "닉네임은 영문과 숫자를 조합하여 6자~10자 사이로 설정해주세요.")
+    private String nickname;
+
+    @NotNull(message = "직무는 필수 선택 값입니다.")
+    private Long positionId;
+
+    @NotEmpty(message = "관심스택은 필수 선택 값입니다.")
+    private List<Long> techStackIds;
+
+    private String intro;
+}

--- a/src/main/java/com/example/demo/global/exception/customexception/UserCustomException.java
+++ b/src/main/java/com/example/demo/global/exception/customexception/UserCustomException.java
@@ -19,6 +19,9 @@ public class UserCustomException extends CustomException {
     public static final UserCustomException INVALID_AUTHENTICATION =
             new UserCustomException(UserErrorCode.INVALID_AUTHENTICATION);
 
+    public static final UserCustomException ALREADY_OAUTH_USER =
+            new UserCustomException(UserErrorCode.ALREADY_OAUTH_USER);
+
     public UserCustomException(UserErrorCode userErrorCode) {
         super(userErrorCode);
     }

--- a/src/main/java/com/example/demo/global/exception/errorcode/UserErrorCode.java
+++ b/src/main/java/com/example/demo/global/exception/errorcode/UserErrorCode.java
@@ -10,7 +10,8 @@ public enum UserErrorCode implements ErrorCode {
     ALREADY_NICKNAME(HttpStatus.CONFLICT, "이미 사용중인 닉네임입니다."),
     DOES_NOT_EXIST_PROFILE_IMG(HttpStatus.NOT_FOUND, "요청한 회원의 프로필 이미지가 존재하지 않습니다."),
     INVALID_AUTHENTICATION(HttpStatus.BAD_REQUEST, "사용자 인증에 실패하였습니다. 이메일 혹은 비밀번호를 확인해주세요."),
-    ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "요청한 URI에 접근할 권한이 존재하지 않습니다.");
+    ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "요청한 URI에 접근할 권한이 존재하지 않습니다."),
+    ALREADY_OAUTH_USER(HttpStatus.CONFLICT, "이미 가입된 소셜 회원입니다.");
 
     private HttpStatus status;
     private String message;

--- a/src/main/java/com/example/demo/repository/user/UserRepository.java
+++ b/src/main/java/com/example/demo/repository/user/UserRepository.java
@@ -20,4 +20,7 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
     // provider, provider_id로 회원조회
     @Query(value = "select u from User u where u.oAuthProvider = :provider and u.oAuthProviderId = :providerId")
     Optional<User> findByProviderAndProviderId(OAuthProvider provider, String providerId);
+
+    @Query("SELECT CASE WHEN COUNT(u) > 0 THEN true ELSE false END FROM User u WHERE u.oAuthProvider = :oAuthProvider AND u.oAuthProviderId = :oAuthProviderId")
+    boolean existsByOAuthProviderAndOAuthProviderId(OAuthProvider oAuthProvider, String oAuthProviderId);
 }

--- a/src/main/java/com/example/demo/service/user/UserService.java
+++ b/src/main/java/com/example/demo/service/user/UserService.java
@@ -1,5 +1,6 @@
 package com.example.demo.service.user;
 
+import com.example.demo.constant.OAuthProvider;
 import com.example.demo.dto.common.ResponseDto;
 import com.example.demo.model.user.User;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,4 +24,8 @@ public interface UserService {
 
     // 회원의 모든 정보 조회
     User fetchUserDetails(Long userId);
+
+    // 소셜 회원 여부
+    boolean existUserByOAuthProviderAndOAuthProviderId(OAuthProvider oAuthProvider, String oAuthProviderId);
+
 }

--- a/src/main/java/com/example/demo/service/user/UserServiceImpl.java
+++ b/src/main/java/com/example/demo/service/user/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.demo.service.user;
 
+import com.example.demo.constant.OAuthProvider;
 import com.example.demo.dto.common.ResponseDto;
 import com.example.demo.global.exception.customexception.UserCustomException;
 import com.example.demo.model.user.User;
@@ -49,5 +50,11 @@ public class UserServiceImpl implements UserService {
     @Override
     public User fetchUserDetails(Long userId) {
         return userRepository.fetchUserByUserIdWithAllAttributes(userId);
+    }
+
+    @Override
+    public boolean existUserByOAuthProviderAndOAuthProviderId(OAuthProvider oAuthProvider, String oAuthProviderId) {
+        return userRepository
+                .existsByOAuthProviderAndOAuthProviderId(oAuthProvider, oAuthProviderId);
     }
 }


### PR DESCRIPTION
### 작업내용
- 소셜 로그인 후 서비스에 가입되지 않은 회원인 경우 서비스 회원가입을 위한 OAuth 회원가입 로직 구현
- 클라이언트로부터 oAuthProvider(OAuth 제공자), oAuthProviderId(OAuth 고유번호), nickname, positionId, techStackIds, intro 요청
- 소셜 회원가입은 일반 회원가입과 동일하지만 email, password 값을 요청, 저장하지 않고 OAuth 제공자 정보와 OAuth 고유번호 정보를 저장 
- 요청받은 OAuth 제공자 정보와 OAuth 고유번호로 이미 가입된 회원인지 검증하는 로직 및 커스텀 예외, 에러코드 추가<br><br><br>
### 연관이슈
#386 