### PR TITLE
[enhancement/modify-user-techstacks-cascade] User 엔티티 techStacks 필드 수정 (속성 추가)

### DIFF
--- a/src/main/java/com/example/demo/model/user/User.java
+++ b/src/main/java/com/example/demo/model/user/User.java
@@ -95,6 +95,9 @@ public class User extends BaseTimeEntity {
         this.techStacks.add(userTechnologyStack);
     }
 
+    // 모든 기술스택 삭제
+    public void removeAllTechStacks() { this.techStacks.clear(); }
+
     // 신뢰점수 등록
     public void setTrustScore(TrustScore trustScore) {
         this.trustScore = trustScore;

--- a/src/main/java/com/example/demo/model/user/User.java
+++ b/src/main/java/com/example/demo/model/user/User.java
@@ -36,7 +36,7 @@ public class User extends BaseTimeEntity {
     @JoinColumn(name = "position_id")
     private Position position;
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.PERSIST)
     private List<UserTechnologyStack> techStacks = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
### 작업내용
- User 엔티티 생성 시 또는 User 엔티티의 techStacks 필드에 데이터 추가 및 삭제 시 자동으로 UserTechnologyStack 테이블에도 반영되도록 하기 위해 User 엔티티의 회원 기술스택 목록을 저장하는 techStacks 필드에 `orphanRemoval = true`, `cascade = CascadeType.PERSIST` 옵션 추가
- User 엔티티에 해당 회원의 모든 기술스택 목록을 제거하는 메소드 구현
- 회원가입, 소셜 회원가입, 회원수정, 회원탈퇴 로직에서 User의 TechStack 추가 및 삭제하는 로직 코드 수정