### PR TITLE
[bugfix/422-work-delete] 업무 삭제 요청 시 버그 수정

### DIFF
--- a/src/main/java/com/example/demo/controller/work/WorkController.java
+++ b/src/main/java/com/example/demo/controller/work/WorkController.java
@@ -66,8 +66,10 @@ public class WorkController {
     }
 
     @DeleteMapping("/api/work/{workId}")
-    public ResponseEntity<ResponseDto<?>> delete(@PathVariable("workId") Long workId) {
-        workService.delete(workId);
+    public ResponseEntity<ResponseDto<?>> delete(
+            @AuthenticationPrincipal PrincipalDetails user,
+            @PathVariable("workId") Long workId) {
+        workFacade.deleteWork(user.getId(), workId);
         return new ResponseEntity<>(ResponseDto.success("success"), HttpStatus.OK);
     }
 

--- a/src/main/java/com/example/demo/repository/alert/AlertRepository.java
+++ b/src/main/java/com/example/demo/repository/alert/AlertRepository.java
@@ -4,6 +4,8 @@ import com.example.demo.model.alert.Alert;
 import com.example.demo.model.project.Project;
 import java.util.List;
 import java.util.Optional;
+
+import com.example.demo.model.work.Work;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -26,4 +28,6 @@ public interface AlertRepository extends JpaRepository<Alert, Long>, AlertReposi
     Optional<List<Alert>> findCrewAlertsByProject(@Param(value = "project") Project project);
 
     void deleteAllByProject(Project project);
+
+    void deleteAllByWork(Work work);
 }

--- a/src/main/java/com/example/demo/service/alert/AlertService.java
+++ b/src/main/java/com/example/demo/service/alert/AlertService.java
@@ -7,6 +7,7 @@ import com.example.demo.model.project.Project;
 import java.util.List;
 
 import com.example.demo.model.user.User;
+import com.example.demo.model.work.Work;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,4 +26,6 @@ public interface AlertService {
     PaginationResponseDto findAlertsBySendUserIdAndType(User user, int pageIndex, int itemCount);
 
     void deleteAllByProject(Project project);
+
+    void deleteAllByWork(Work work);
 }

--- a/src/main/java/com/example/demo/service/alert/AlertServiceImpl.java
+++ b/src/main/java/com/example/demo/service/alert/AlertServiceImpl.java
@@ -8,6 +8,7 @@ import com.example.demo.global.exception.customexception.AlertCustomException;
 import com.example.demo.model.alert.Alert;
 import com.example.demo.model.project.Project;
 import com.example.demo.model.user.User;
+import com.example.demo.model.work.Work;
 import com.example.demo.repository.alert.AlertRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -61,4 +62,7 @@ public class AlertServiceImpl implements AlertService {
     public void deleteAllByProject(Project project) {
         alertRepository.deleteAllByProject(project);
     }
+
+    @Override
+    public void deleteAllByWork(Work work) { alertRepository.deleteAllByWork(work); }
 }

--- a/src/main/java/com/example/demo/service/work/WorkService.java
+++ b/src/main/java/com/example/demo/service/work/WorkService.java
@@ -22,7 +22,7 @@ public interface WorkService {
 
     public PaginationResponseDto findWorksByProjectAndMilestone(Long projectId, Long milestoneId, Pageable pageable);
 
-    public void delete(Long workId);
+    public void delete(Work work);
 
     // 특정 프로젝트에 할당된 특정 회원의 업무 내역 + 업무 신뢰점수 내역 조회
     PaginationResponseDto findWorksWithTrustScoreHistoryByProjectIdAndAssignedUserId(Long projectId, Long assignedUserId, Pageable pageable);

--- a/src/main/java/com/example/demo/service/work/WorkServiceImpl.java
+++ b/src/main/java/com/example/demo/service/work/WorkServiceImpl.java
@@ -44,10 +44,7 @@ public class WorkServiceImpl implements WorkService {
                 .findWorkByProjectIdAndMilestoneIdOrderByStartDateAsc(projectId, milestoneId, pageable);
     }
 
-    public void delete(Long workId) {
-        Work work = findById(workId);
-        workRepository.delete(work);
-    }
+    public void delete(Work work) { workRepository.delete(work); }
 
     @Override
     public PaginationResponseDto findWorksWithTrustScoreHistoryByProjectIdAndAssignedUserId(Long projectId, Long assignedUserId, Pageable pageable) {


### PR DESCRIPTION
### 작업내용
- 기존 업무 삭제 요청 시 해당 업무 정보를 가진 알림 데이터가 존재하는 경우 삭제되지 않고 오류가 발생하는 버그 해결
- 업무 삭제 요청 시 요청한 회원 정보를 추가로 받아 요청한 회원이 업무가 속한 프로젝트의 멤버인지 검증하고 해당 업무를 삭제하기 전 해당 업무 정보를 가진 알림 데이터 목록을 함께 삭제하도록 로직 새로 구현<br><br><br>
### 연관이슈
close #422 