### PR TITLE
[feature/add-field-trust-score-history] 신뢰점수 이력 엔티티에 새로운 필드 추가

### DIFF
--- a/src/main/java/com/example/demo/dto/trust_score/AddPointDto.java
+++ b/src/main/java/com/example/demo/dto/trust_score/AddPointDto.java
@@ -8,6 +8,7 @@ import lombok.Data;
 @Data
 @ValidAddPointDto
 public class AddPointDto {
+    private String content;
     private Long userId;
     private Long projectId;
     private Long milestoneId;
@@ -24,7 +25,8 @@ public class AddPointDto {
 
     @Builder
     public AddPointDto(
-            Long userId, Long projectId, Long milestoneId, Long workId, Long scoreTypeId) {
+            String content, Long userId, Long projectId, Long milestoneId, Long workId, Long scoreTypeId) {
+        this.content = content;
         this.userId = userId;
         this.projectId = projectId;
         this.milestoneId = milestoneId;

--- a/src/main/java/com/example/demo/model/trust_score/TrustScoreHistory.java
+++ b/src/main/java/com/example/demo/model/trust_score/TrustScoreHistory.java
@@ -35,6 +35,8 @@ public class TrustScoreHistory extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "trust_score_history_id")
     Long id;
+    /** 신뢰점수 내용 */
+    private String content;
     /** 사용자 자동생성 식별자 */
     @Column private Long userId;
     /** 신뢰점수타입 자동생성 식별자 */
@@ -50,12 +52,14 @@ public class TrustScoreHistory extends BaseTimeEntity {
 
     @Builder
     public TrustScoreHistory(
+            String content,
             Long userId,
             Long trustScoreTypeId,
             Long projectId,
             Long milestoneId,
             int score,
             Long workId) {
+        this.content = content;
         this.userId = userId;
         this.trustScoreTypeId = trustScoreTypeId;
         this.projectId = projectId;

--- a/src/test/java/com/example/demo/service/trust_score/AddPointTest.java
+++ b/src/test/java/com/example/demo/service/trust_score/AddPointTest.java
@@ -40,7 +40,7 @@ class AddPointTest {
     void validWorkComplete() {
         scoreTypeId = TrustScoreTypeIdentifier.WORK_COMPLETE;
         AddPointDto addPointDto =
-                new AddPointDto(userId, projectId, milestoneId, workId, scoreTypeId);
+                new AddPointDto("", userId, projectId, milestoneId, workId, scoreTypeId);
         TrustScoreUpdateResponseDto responseDto = trustScoreService.addPoint(addPointDto);
         Assertions.assertThat(responseDto.getScoreChange()).isEqualTo(30);
     }
@@ -50,7 +50,7 @@ class AddPointTest {
     void validWorkIncomplete() {
         scoreTypeId = TrustScoreTypeIdentifier.WORK_INCOMPLETE;
         AddPointDto addPointDto =
-                new AddPointDto(userId, projectId, milestoneId, workId, scoreTypeId);
+                new AddPointDto("", userId, projectId, milestoneId, workId, scoreTypeId);
         TrustScoreUpdateResponseDto responseDto = trustScoreService.addPoint(addPointDto);
         Assertions.assertThat(responseDto.getScoreChange()).isEqualTo(-15);
     }
@@ -59,7 +59,7 @@ class AddPointTest {
     @DisplayName("유효하지 않은 업무 완수 요청에 대한 테스트입니다.")
     void invalidWorkComplete() {
         scoreTypeId = TrustScoreTypeIdentifier.WORK_COMPLETE;
-        AddPointDto addPointDto = new AddPointDto(userId, null, milestoneId, workId, scoreTypeId);
+        AddPointDto addPointDto = new AddPointDto("", userId, null, milestoneId, workId, scoreTypeId);
         Set<ConstraintViolation<AddPointDto>> violations = validator.validate(addPointDto);
         Assertions.assertThat(violations).isNotEmpty();
     }
@@ -68,7 +68,7 @@ class AddPointTest {
     @DisplayName("유효하지 않은 신규멤버 입력값에 대한 테스트입니다.")
     void invalidNewMember() {
         scoreTypeId = TrustScoreTypeIdentifier.NEW_MEMBER;
-        AddPointDto addPointDto = new AddPointDto(userId, null, milestoneId, workId, scoreTypeId);
+        AddPointDto addPointDto = new AddPointDto("", userId, null, milestoneId, workId, scoreTypeId);
         Set<ConstraintViolation<AddPointDto>> violations = validator.validate(addPointDto);
         Assertions.assertThat(violations).isNotEmpty();
     }
@@ -77,7 +77,7 @@ class AddPointTest {
     @DisplayName("유효한 신규멤버 입력값에 대한 테스트입니다.")
     void validNewMember() {
         scoreTypeId = TrustScoreTypeIdentifier.NEW_MEMBER;
-        AddPointDto addPointDto = new AddPointDto(userId, null, milestoneId, workId, scoreTypeId);
+        AddPointDto addPointDto = new AddPointDto("", userId, null, milestoneId, workId, scoreTypeId);
         Set<ConstraintViolation<AddPointDto>> violations = validator.validate(addPointDto);
         Assertions.assertThat(violations).isNotEmpty();
     }
@@ -86,7 +86,7 @@ class AddPointTest {
     @DisplayName("프로젝트 탈퇴에 대한 유효성 검증 - 실패")
     void invalidWithdrawal() {
         scoreTypeId = TrustScoreTypeIdentifier.SELF_WITHDRAWAL;
-        AddPointDto addPointDto = new AddPointDto(userId, 101L, milestoneId, workId, scoreTypeId);
+        AddPointDto addPointDto = new AddPointDto("", userId, 101L, milestoneId, workId, scoreTypeId);
         Set<ConstraintViolation<AddPointDto>> violations = validator.validate(addPointDto);
         Assertions.assertThat(violations).isNotEmpty();
     }


### PR DESCRIPTION
### 작업내용
- TrustScoreHistory 엔티티에 신뢰점수 내용 content 필드 추가 (ex. 회원가입, 업무 완료, 업무 만료, 프로젝트 멤버 탈퇴 등)
- 신뢰점수 부여, 차감 요청 시 필요한 AddPointDto에 content 필드 추가
- AddPointDto 테스트 코드 수정, 생성자 content 필드에 빈 값("") 셋팅