### PR TITLE
[feature/fix-work-confirm-trust-score-history] 업무 컨펌 로직에서 신뢰점수 이력 관련 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/service/work/WorkFacade.java
+++ b/src/main/java/com/example/demo/service/work/WorkFacade.java
@@ -172,13 +172,17 @@ public class WorkFacade {
         projectMemberService.verifiedProjectManager(project, currentUser);
 
         Work work = alert.getWork();
+        ProgressStatus workStatus = work.getProgressStatus();
         // 업무가 기간만료된 상태라면
-        if(work.getProgressStatus().equals(ProgressStatus.EXPIRED)) {
+        if(workStatus.equals(ProgressStatus.EXPIRED)) {
             workConfirmRequest.updateScoreTypeId(22L);
         }
 
         // 신뢰점수 부여 DTO
         AddPointDto addPoint = AddPointDto.builder()
+                .content(work.getContent() + " " +
+                        (workStatus.equals(ProgressStatus.COMPLETION) ? (workConfirmRequest.getScoreTypeId().equals(1L) ? "완수" : "미흡") : "만료")
+                )
                 .userId(alert.getSendUser().getId())
                 .projectId(project.getId())
                 .milestoneId(alert.getMilestone().getId())


### PR DESCRIPTION
### 작업내용
- 업무 컨펌 로직에서 해당 업무 상태에 따른 신뢰점수 부여 시 content 필드도 함께 셋팅하도록 수정
- 신뢰점수 이력 content 필드에 `업무 내용` + `특정 업무 신뢰점수 타입` 형태로 저장하도록 구현
- 특정 업무 신뢰점수 타입
    - 업무 상태가 `COMPLETION(완료)` AND 요청 scoreType이 `+(1)`인 경우 -> `완수`
    - 업무 상태가 `COMPLETION(완료)` AND 요청 scoreType이 `-(2)`인 경우 -> `미흡`
    - 업무 상태가 `EXPIRED(기간만료)` -> `만료`