### PR TITLE
[feature/425-fix-project-member-work-history] 프로젝트 멤버의 업무 + 신뢰 이력 조회 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/dto/projectmember/response/ProjectMemberWorkWithTrustScoreResponseDto.java
+++ b/src/main/java/com/example/demo/dto/projectmember/response/ProjectMemberWorkWithTrustScoreResponseDto.java
@@ -1,34 +1,29 @@
 package com.example.demo.dto.projectmember.response;
 
 import com.example.demo.constant.ProgressStatus;
+import com.example.demo.global.util.LocalDateTimeFormatSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Getter
 public class ProjectMemberWorkWithTrustScoreResponseDto {
 
-    private Long workId;
-    private String workContent;
-    private String workContentDetail;
-    private LocalDate startDate;
-    private LocalDate endDate;
-    private String progressStatus;
     private Long trustScoreHistoryId;
+    private String workContent;
     private Integer point;
     private String point_type;
+    @JsonSerialize(using = LocalDateTimeFormatSerializer.class)
+    private LocalDateTime createDate;
 
-    public ProjectMemberWorkWithTrustScoreResponseDto(Long workId, String workContent, String workContentDetail, LocalDate startDate,
-                                                      LocalDate endDate, ProgressStatus progressStatus, Long trustScoreHistoryId, Integer point) {
-        this.workId = workId;
-        this.workContent = workContent;
-        this.workContentDetail = workContentDetail;
-        this.startDate = startDate;
-        this.endDate = endDate;
-        this.progressStatus = progressStatus.getDescription();
+    public ProjectMemberWorkWithTrustScoreResponseDto(Long trustScoreHistoryId, String workContent, Integer point, LocalDateTime createDate) {
         this.trustScoreHistoryId = trustScoreHistoryId;
+        this.workContent = workContent;
         this.point = point < 0 ? -(point) : point;
         this.point_type = point < 0 ? "minus" : "plus";
+        this.createDate = createDate;
     }
 }

--- a/src/main/java/com/example/demo/repository/trust_score/TrustScoreHistoryRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/trust_score/TrustScoreHistoryRepositoryCustom.java
@@ -1,10 +1,16 @@
 package com.example.demo.repository.trust_score;
 
+import com.example.demo.dto.common.PaginationResponseDto;
 import com.example.demo.dto.trust_score.ProjectUserHistoryDto;
+import org.springframework.data.domain.Pageable;
+
 import java.util.List;
 
 public interface TrustScoreHistoryRepositoryCustom {
     List<ProjectUserHistoryDto> getProjectUserHistory(Long projectId, Long userId);
 
     int calculateCurrentScore(Long userId);
+
+    // 특정 프로젝트 멤버의 업무 신뢰점수 이력 목록 조회 (페이징, 최신순 정렬)
+    PaginationResponseDto findByProjectAndUserAndWorkIsNotNullOrderByCreateDate(Long projectId, Long userId, Pageable pageable);
 }

--- a/src/main/java/com/example/demo/repository/trust_score/TrustScoreHistoryRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/trust_score/TrustScoreHistoryRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.example.demo.repository.trust_score;
 
+import com.example.demo.dto.common.PaginationResponseDto;
+import com.example.demo.dto.projectmember.response.ProjectMemberWorkWithTrustScoreResponseDto;
 import com.example.demo.dto.trust_score.ProjectUserHistoryDto;
 import com.example.demo.model.trust_score.QTrustScoreHistory;
 import com.example.demo.model.work.QWork;
@@ -8,6 +10,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Slf4j
@@ -15,6 +18,7 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class TrustScoreHistoryRepositoryImpl implements TrustScoreHistoryRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
+    private final QTrustScoreHistory qTrustScoreHistory = QTrustScoreHistory.trustScoreHistory;
     /**
      * 특정 프로젝트에 참여하는 사용자의, 해당 프로젝트 관련 발생한 신뢰점수이력을 DTO 형태로 반환
      *
@@ -60,5 +64,41 @@ public class TrustScoreHistoryRepositoryImpl implements TrustScoreHistoryReposit
             log.error("error :", ne);
             return 0;
         }
+    }
+
+    @Override
+    public PaginationResponseDto findByProjectAndUserAndWorkIsNotNullOrderByCreateDate(Long projectId, Long userId, Pageable pageable) {
+        List<ProjectMemberWorkWithTrustScoreResponseDto> content = jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                ProjectMemberWorkWithTrustScoreResponseDto.class,
+                                qTrustScoreHistory.id,
+                                qTrustScoreHistory.content,
+                                qTrustScoreHistory.score,
+                                qTrustScoreHistory.createDate
+                        )
+                )
+                .from(qTrustScoreHistory)
+                .where(qTrustScoreHistory.projectId.eq(projectId),
+                        qTrustScoreHistory.userId.eq(userId),
+                        qTrustScoreHistory.workId.isNotNull())
+                .orderBy(qTrustScoreHistory.createDate.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long totalPages = countByProjectAndUserAndWorkIsNotNull(projectId, userId);
+
+        return PaginationResponseDto.of(content, totalPages);
+    }
+
+    private Long countByProjectAndUserAndWorkIsNotNull(Long projectId, Long userId) {
+        return jpaQueryFactory
+                .select(qTrustScoreHistory.count())
+                .from(qTrustScoreHistory)
+                .where(qTrustScoreHistory.projectId.eq(projectId),
+                        qTrustScoreHistory.userId.eq(userId),
+                        qTrustScoreHistory.workId.isNotNull())
+                .fetchOne();
     }
 }

--- a/src/main/java/com/example/demo/repository/work/WorkRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/work/WorkRepositoryCustom.java
@@ -7,7 +7,4 @@ public interface WorkRepositoryCustom {
 
     // 프로젝트 > 마일스톤 > 업무 리스트 조회 (시작날짜 기준 오름차순 정렬, 페이징)
     PaginationResponseDto findWorkByProjectIdAndMilestoneIdOrderByStartDateAsc(Long projectId, Long milestoneId, Pageable pageable);
-
-    // 특정 프로젝트에 할당된 프로젝트 멤버의 업무 내역 + 업무 별 신뢰점수 내역 조회 (시작날짜 기준 최신순 정렬, 페이징)
-    PaginationResponseDto findWorksWithTrustScoreHistoryByProjectIdAndAssignedUserIdOrderByStartDateDesc(Long projectId, Long assignedUserId, Pageable pageable);
 }

--- a/src/main/java/com/example/demo/repository/work/WorkRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/work/WorkRepositoryImpl.java
@@ -82,40 +82,6 @@ public class WorkRepositoryImpl implements WorkRepositoryCustom{
         return PaginationResponseDto.of(content, totalPages);
     }
 
-    @Override
-    public PaginationResponseDto findWorksWithTrustScoreHistoryByProjectIdAndAssignedUserIdOrderByStartDateDesc(Long projectId, Long assignedUserId, Pageable pageable) {
-        // 프로젝트 멤버 업무 목록 + 업무 별 신뢰점수 내역 조회
-        List<ProjectMemberWorkWithTrustScoreResponseDto> content = jpaQueryFactory
-                .select(
-                        Projections.constructor(
-                                ProjectMemberWorkWithTrustScoreResponseDto.class,
-                                qWork.id,
-                                qWork.content,
-                                qWork.contentDetail,
-                                qWork.startDate,
-                                qWork.endDate,
-                                qWork.progressStatus,
-                                qTrustScoreHistory.id,
-                                qTrustScoreHistory.score
-                        )
-                )
-                .from(qWork)
-                .join(qTrustScoreHistory).on(qWork.id.eq(qTrustScoreHistory.workId))
-                .where(
-                        eqProjectId(projectId),
-                        eqAssignedUserId(assignedUserId)
-                )
-                .orderBy(qWork.startDate.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
-
-        // 업무 전체 갯수 조회
-        long totalPages = getTotalItemCount(projectId, null, assignedUserId);
-
-        return PaginationResponseDto.of(content, totalPages);
-    }
-
     // 조건에 맞는 업무의 총 개수 조회
     private Long getTotalItemCount(Long projectId, Long milestoneId, Long assignedUserId) {
         return jpaQueryFactory

--- a/src/main/java/com/example/demo/service/project/ProjectMemberFacade.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberFacade.java
@@ -240,7 +240,8 @@ public class ProjectMemberFacade {
         ProjectMember projectMember = projectMemberService.findById(projectMemberId);
 
         // 해당 프로젝트 멤버의 업무 + 업무 별 신뢰점수 내역 & 해당 프로젝트 멤버 업무 총 개수 조회
-        PaginationResponseDto result = workService.findWorksWithTrustScoreHistoryByProjectIdAndAssignedUserId(projectMember.getProject().getId(), projectMember.getUser().getId(), PageRequest.of(pageIndex, itemCount));
+        PaginationResponseDto result = trustScoreHistoryService
+                .getWorkTrustScoreHistories(projectMember.getProject(), projectMember.getUser(), pageIndex, itemCount);
 
         return result;
     }

--- a/src/main/java/com/example/demo/service/trust_score/TrustScoreHistoryService.java
+++ b/src/main/java/com/example/demo/service/trust_score/TrustScoreHistoryService.java
@@ -1,3 +1,11 @@
 package com.example.demo.service.trust_score;
 
-public interface TrustScoreHistoryService {}
+import com.example.demo.dto.common.PaginationResponseDto;
+import com.example.demo.model.project.Project;
+import com.example.demo.model.user.User;
+
+public interface TrustScoreHistoryService {
+
+    // 업무 관련 신뢰점수 이력 목록 조회
+    PaginationResponseDto getWorkTrustScoreHistories(Project project, User user, int pageIndex, int itemCount);
+}

--- a/src/main/java/com/example/demo/service/trust_score/TrustScoreHistoryServiceImpl.java
+++ b/src/main/java/com/example/demo/service/trust_score/TrustScoreHistoryServiceImpl.java
@@ -1,11 +1,21 @@
 package com.example.demo.service.trust_score;
 
+import com.example.demo.dto.common.PaginationResponseDto;
+import com.example.demo.model.project.Project;
+import com.example.demo.model.user.User;
 import com.example.demo.repository.trust_score.TrustScoreHistoryRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class TrustScoreHistoryServiceImpl implements TrustScoreHistoryService {
     private final TrustScoreHistoryRepository trustScoreHistoryRepository;
+
+    @Override
+    public PaginationResponseDto getWorkTrustScoreHistories(Project project, User user, int pageIndex, int itemCount) {
+        return trustScoreHistoryRepository
+                .findByProjectAndUserAndWorkIsNotNullOrderByCreateDate(project.getId(), user.getId(), PageRequest.of(pageIndex, itemCount));
+    }
 }

--- a/src/main/java/com/example/demo/service/work/WorkService.java
+++ b/src/main/java/com/example/demo/service/work/WorkService.java
@@ -12,20 +12,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public interface WorkService {
 
-    public Work save(Work work);
+    Work save(Work work);
 
-    public Work findById(Long id);
+    Work findById(Long id);
 
-    public List<Work> findWorksByProject(Project project);
+    List<Work> findWorksByProject(Project project);
 
-    public Work findLastCompleteWork(Project project, User user);
+    Work findLastCompleteWork(Project project, User user);
 
-    public PaginationResponseDto findWorksByProjectAndMilestone(Long projectId, Long milestoneId, Pageable pageable);
+    PaginationResponseDto findWorksByProjectAndMilestone(Long projectId, Long milestoneId, Pageable pageable);
 
-    public void delete(Work work);
-
-    // 특정 프로젝트에 할당된 특정 회원의 업무 내역 + 업무 신뢰점수 내역 조회
-    PaginationResponseDto findWorksWithTrustScoreHistoryByProjectIdAndAssignedUserId(Long projectId, Long assignedUserId, Pageable pageable);
+    void delete(Work work);
 
     void deleteAllByProject(Project project);
 }

--- a/src/main/java/com/example/demo/service/work/WorkServiceImpl.java
+++ b/src/main/java/com/example/demo/service/work/WorkServiceImpl.java
@@ -47,11 +47,6 @@ public class WorkServiceImpl implements WorkService {
     public void delete(Work work) { workRepository.delete(work); }
 
     @Override
-    public PaginationResponseDto findWorksWithTrustScoreHistoryByProjectIdAndAssignedUserId(Long projectId, Long assignedUserId, Pageable pageable) {
-        return workRepository.findWorksWithTrustScoreHistoryByProjectIdAndAssignedUserIdOrderByStartDateDesc(projectId, assignedUserId, pageable);
-    }
-
-    @Override
     public void deleteAllByProject(Project project) {
         workRepository.deleteAllByProject(project);
     }


### PR DESCRIPTION
### 작업내용
- 기존 프로젝트 멤버의 업무와 해당 업무의 신뢰점수 이력 목록을 불러오는 로직에서 만약 특정 업무가 삭제된 경우 삭제된 업무의 신뢰점수 이력을 조회하지 못하는 버그 수정
- 기존 로직을 삭제하고 삭제된 업무를 대비해 Work 테이블에서 조회하지 않고 TrustScoreHistory 테이블에서 work_id 필드가 null이 아니고 특정 프로젝트 멤버의 프로젝트 정보, 회원 정보와 일치하는 신뢰점수 이력 목록을 조회하는 로직 새로 구현
- 해당 요청의 응답 값으로 TrustScoreHistoryId, workContent(TrustScoreHistory의 content 필드), point, point_type, createDate 데이터를 응답하도록 수정
```
"data": {
        "content": [
            {
                "trustScoreHistoryId": 317,
                "workContent": "업무 테스트 완수",
                "point": 20,
                "point_type": "plus",
                "createDate": "2024-02-20"
            }
        ],
        "totalPages": 1
    }
```
<br><br><br>
### 연관이슈
close #425 