### PR TITLE
[feature/fix-project-member-force-withdrawal] 프로젝트 멤버 강제탈퇴 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/global/validation/validator/AddPointDtoValidator.java
+++ b/src/main/java/com/example/demo/global/validation/validator/AddPointDtoValidator.java
@@ -3,6 +3,7 @@ package com.example.demo.global.validation.validator;
 import static com.example.demo.constant.TrustScoreTypeIdentifier.*;
 
 import com.example.demo.constant.ProgressStatus;
+import com.example.demo.constant.ProjectMemberStatus;
 import com.example.demo.dto.trust_score.AddPointDto;
 import com.example.demo.global.exception.customexception.ProjectCustomException;
 import com.example.demo.global.exception.customexception.UserCustomException;
@@ -190,10 +191,13 @@ public class AddPointDtoValidator implements ConstraintValidator<ValidAddPointDt
         Optional<ProjectMember> findProjectMember =
                 projectMemberRepository.findProjectMemberByProjectAndUser(project, user);
 
-        if (findProjectMember.isPresent()) {
-            log.info(
-                    "잘못된 입력값. 프로젝트에 회원 정보 존재. findProjectMemberId : {}",
-                    findProjectMember.get().getId());
+        if (!findProjectMember.isPresent()) {
+            log.info("잘못된 입력값. 프로젝트에 해당 멤버가 존재하지 않음.");
+            return false;
+        }
+
+        if(!findProjectMember.get().getStatus().equals(ProjectMemberStatus.PARTICIPATING)) {
+            log.info("잘못된 입력값. 프로젝트 멤버의 상태가 이미 탈퇴했거나 참여중이 아닌 회원. projectMemberStatus : {}", findProjectMember.get().getStatus());
             return false;
         }
 


### PR DESCRIPTION
### 작업내용
- 프로젝트 멤버 강제탈퇴 로직에 강제탈퇴에 따른 해당 멤버의 신뢰점수를 차감하는 로직 추가
- 신뢰점수 부여 및 차감 DTO AddPointDto 검증 로직 중 프로젝트 멤버 탈퇴, 강제탈퇴 로직 수정
    - 요청한 프로젝트 멤버가 없는 경우, 요청한 프로젝트 멤버의 상태가 참여중이 아닌 경우 검증 실패하도록 수정