### PR TITLE
[feature/add-security-antmatcher] 스프링 시큐리티 제외 uri 추가

### DIFF
--- a/src/main/java/com/example/demo/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/global/config/SecurityConfig.java
@@ -75,7 +75,7 @@ public class SecurityConfig {
 
     @Bean
     public WebSecurityCustomizer configure() throws Exception {
-        return (web) -> web.ignoring().antMatchers();
+        return (web) -> web.ignoring().antMatchers("/favicon.ico");
     }
 
     @Bean


### PR DESCRIPTION
### 작업내용
- 아이콘 관련 브라우저가 자동으로 요청하는 정적 자원(리소스)에 대한 `/favicon.ico` 경로를 스프링 시큐리티에서 제외
- 해당 요청 시 스프링 시큐리티 필터체인의 JWT 인증 부분에서 예외를 응답하는 버그 수정