### PR TITLE
[feature/fix-entity-enum-field] 엔티티 Enum Type의 필드 수정

### DIFF
--- a/src/main/java/com/example/demo/model/alert/Alert.java
+++ b/src/main/java/com/example/demo/model/alert/Alert.java
@@ -48,6 +48,7 @@ public class Alert extends BaseTimeEntity {
 
     private String content;
 
+    @Enumerated(value = EnumType.STRING)
     private AlertType type;
 
     @Column(name = "checked_yn")

--- a/src/main/java/com/example/demo/model/project/ProjectMember.java
+++ b/src/main/java/com/example/demo/model/project/ProjectMember.java
@@ -34,6 +34,7 @@ public class ProjectMember extends BaseTimeEntity {
     @JoinColumn(name = "project_member_auth_id")
     private ProjectMemberAuth projectMemberAuth;
 
+    @Enumerated(value = EnumType.STRING)
     @Column(name = "project_member_status")
     private ProjectMemberStatus status;
 


### PR DESCRIPTION
### 작업내용
- Alert 엔티티 AlertType Enum 타입의 type 필드, ProjectMember 엔티티 ProjectMemberStatus 타입의 status 필드에 `@Enumerated(value = EnumType.String)` 를 적용해 String 타입으로 관리하도록 수정, 모든 엔티티의 Enum 필드 공통화
-Enum 데이터에서 값을 삭제하거나 새로운 값을 추가할 경우, 기존 Enum 데이터들의 인덱스 정보에 영향을 끼쳐 오류가 발생하는 문제를 해결하기 위해 Database에 Enum 데이터를 저장 시 인덱스가 아닌 String 타입으로 저장되도록 수정