### PR TITLE
[fix/enum-typo-alert-type] 알림타입 Enum 데이터 오타 수정

### DIFF
--- a/src/main/java/com/example/demo/constant/AlertType.java
+++ b/src/main/java/com/example/demo/constant/AlertType.java
@@ -4,6 +4,6 @@ public enum AlertType {
     RECRUIT,
     WORK,
     ADD,
-    WITHDRAWL,
-    FORCEDWITHDRAWL,
+    WITHDRAWAL,
+    FORCED_WITHDRAWAL,
 }

--- a/src/main/java/com/example/demo/repository/alert/AlertRepository.java
+++ b/src/main/java/com/example/demo/repository/alert/AlertRepository.java
@@ -24,7 +24,7 @@ public interface AlertRepository extends JpaRepository<Alert, Long>, AlertReposi
     Optional<List<Alert>> findWorkAlertsByProject(@Param(value = "project") Project project);
 
     @Query(
-            "select alert from Alert alert where alert.project = :#{#project} and (alert.type = com.example.demo.constant.AlertType.ADD or alert.type = com.example.demo.constant.AlertType.WITHDRAWL or alert.type = com.example.demo.constant.AlertType.FORCEDWITHDRAWL)")
+            "select alert from Alert alert where alert.project = :#{#project} and (alert.type = com.example.demo.constant.AlertType.ADD or alert.type = com.example.demo.constant.AlertType.WITHDRAWAL or alert.type = com.example.demo.constant.AlertType.FORCED_WITHDRAWAL)")
     Optional<List<Alert>> findCrewAlertsByProject(@Param(value = "project") Project project);
 
     void deleteAllByProject(Project project);

--- a/src/main/java/com/example/demo/repository/alert/AlertRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/alert/AlertRepositoryImpl.java
@@ -142,8 +142,8 @@ public class AlertRepositoryImpl implements AlertRepositoryCustom{
         if(alertType != null) {
             if (!alertType.equals(AlertType.RECRUIT) && !alertType.equals(AlertType.WORK)) {
                 return qAlert.type.eq(AlertType.ADD)
-                        .or(qAlert.type.eq(AlertType.WITHDRAWL))
-                        .or(qAlert.type.eq(AlertType.FORCEDWITHDRAWL));
+                        .or(qAlert.type.eq(AlertType.WITHDRAWAL))
+                        .or(qAlert.type.eq(AlertType.FORCED_WITHDRAWAL));
             } else {
                 return qAlert.type.eq(alertType);
             }

--- a/src/main/java/com/example/demo/service/project/ProjectMemberFacade.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberFacade.java
@@ -70,7 +70,7 @@ public class ProjectMemberFacade {
                         .sendUser(user)
                         .content(user.getNickname() + "님이 프로젝트 탈퇴 신청을 했습니다.")
                         .position(projectMember.getPosition())
-                        .type(AlertType.WITHDRAWL)
+                        .type(AlertType.WITHDRAWAL)
                         .checked_YN(false)
                         .build();
 
@@ -115,7 +115,7 @@ public class ProjectMemberFacade {
                     .project(project)
                     .sendUser(currentUser)
                     .content(user.getNickname() + "님이 프로젝트를 탈퇴했습니다.")
-                    .type(AlertType.WITHDRAWL)
+                    .type(AlertType.WITHDRAWAL)
                     .checked_YN(false)
                     .build();
             alertService.save(alert);
@@ -159,7 +159,7 @@ public class ProjectMemberFacade {
                 .project(project)
                 .sendUser(currentUser)
                 .content(user.getNickname() + "님이 " + project.getName() + "에서 강제탈퇴 처리됐습니다.")
-                .type(AlertType.FORCEDWITHDRAWL)
+                .type(AlertType.FORCED_WITHDRAWAL)
                 .checked_YN(false)
                 .build();
         alertService.save(forcedWithdrawalAlert);


### PR DESCRIPTION
### 작업내용
- AlertType Enum 파일의 탈퇴, 강제탈퇴 오타 수정
    - `WITHDRAWL` -> `WITHDRAWAL`
    - `FORCEDWITHDRAWL` -> `FORCED_WITHDRAWAL`
- AlertType Enum 파일에서 탈퇴, 강제탈퇴 데이터를 참조해 사용하는 로직 수정(쿼리 조건문, 알림 엔티티 생성)