### PR TITLE
[fix/user-info-url] 사용자 정보 조회 요청 URL 경로 수정

### DIFF
--- a/src/main/java/com/example/demo/controller/user/UserController.java
+++ b/src/main/java/com/example/demo/controller/user/UserController.java
@@ -29,7 +29,7 @@ public class UserController {
      * @param userId
      * @return
      */
-    @GetMapping("/user/{userId}")
+    @GetMapping("/{userId}")
     public ResponseEntity<ResponseDto<?>> getUserInfoById(@PathVariable String userId){
         return ResponseEntity.status(HttpStatus.OK).body(userFacade.getUserInfoById(Long.parseLong(userId)));
     }


### PR DESCRIPTION
### 작업내용
- 사용자 정보 조회 요청 URL 경로에서 `/user` 패턴이 중복되는 이슈 해결
    - `/api/user/user/{userId}` -> `/api/user/{userId}`