### PR TITLE
[remove/abstract-method-access-modifiers-warning] 추상 메소드 접근제어자 제거 & 중복 경고 해결

### DIFF
--- a/src/main/java/com/example/demo/service/board/BoardPositionService.java
+++ b/src/main/java/com/example/demo/service/board/BoardPositionService.java
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public interface BoardPositionService {
 
-    public BoardPosition getBoardPositionEntity(Board board, Position position);
+    BoardPosition getBoardPositionEntity(Board board, Position position);
 
-    public BoardPosition save(BoardPosition boardPosition);
+    BoardPosition save(BoardPosition boardPosition);
 }

--- a/src/main/java/com/example/demo/service/board/BoardService.java
+++ b/src/main/java/com/example/demo/service/board/BoardService.java
@@ -11,16 +11,15 @@ import org.springframework.transaction.annotation.Transactional;
 public interface BoardService {
 
     @Transactional(readOnly = true)
-    public PaginationResponseDto search(
-            Long positionId, String keyword, List<Long> technologyIds, Pageable pageable);
+    PaginationResponseDto search(Long positionId, String keyword, List<Long> technologyIds, Pageable pageable);
 
-    public Board findById(Long boardId);
+    Board findById(Long boardId);
 
-    public Board save(Board board);
+    Board save(Board board);
 
-    public BoardTotalDetailResponseDto getDetail(Long boardId);
+    BoardTotalDetailResponseDto getDetail(Long boardId);
 
-    public void delete(Board board);
+    void delete(Board board);
 
     @Transactional
     void updateRecruitmentStatus(Long boardId, Long userId);

--- a/src/main/java/com/example/demo/service/milestone/MilestoneService.java
+++ b/src/main/java/com/example/demo/service/milestone/MilestoneService.java
@@ -12,23 +12,21 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public interface MilestoneService {
 
-    public Milestone findById(Long id);
+    Milestone findById(Long id);
 
-    public Milestone save(Milestone milestone);
+    Milestone save(Milestone milestone);
 
-    public List<Milestone> findMilestonesByProject(Project project);
+    List<Milestone> findMilestonesByProject(Project project);
 
-    public MilestoneReadResponseDto getOne(Long milestoneId);
+    MilestoneReadResponseDto getOne(Long milestoneId);
 
-    public void update(Long milestoneId, MileStoneUpdateRequestDto mileStoneUpdateRequestDto);
+    void update(Long milestoneId, MileStoneUpdateRequestDto mileStoneUpdateRequestDto);
 
-    public void delete(Long milestoneId);
+    void delete(Long milestoneId);
 
-    public void updateContent(
-            Long milestoneId, MilestoneUpdateContentRequestDto milestoneUpdateContentRequestDto);
+    void updateContent(Long milestoneId, MilestoneUpdateContentRequestDto milestoneUpdateContentRequestDto);
 
-    public void updateDate(
-            Long milestoneId, MilestoneUpdateDateRequestDto milestoneUpdateDateRequestDto);
+    void updateDate(Long milestoneId, MilestoneUpdateDateRequestDto milestoneUpdateDateRequestDto);
 
     void deleteAllByProject(Project project);
 }

--- a/src/main/java/com/example/demo/service/position/PositionService.java
+++ b/src/main/java/com/example/demo/service/position/PositionService.java
@@ -11,7 +11,7 @@ public interface PositionService {
     @Transactional(readOnly = true)
     ResponseDto<?> getPositionList();
 
-    public Position save(Position position);
+    Position save(Position position);
 
-    public Position findById(Long id);
+    Position findById(Long id);
 }

--- a/src/main/java/com/example/demo/service/project/ProjectMemberAuthService.java
+++ b/src/main/java/com/example/demo/service/project/ProjectMemberAuthService.java
@@ -5,9 +5,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 public interface ProjectMemberAuthService {
-    public ProjectMemberAuth save(ProjectMemberAuth projectMemberAuth);
+    ProjectMemberAuth save(ProjectMemberAuth projectMemberAuth);
 
-    public ProjectMemberAuth findProjectMemberAuthById(Long id);
+    ProjectMemberAuth findProjectMemberAuthById(Long id);
 
-    public ProjectMemberAuth findTopByOrderByIdDesc();
+    ProjectMemberAuth findTopByOrderByIdDesc();
 }

--- a/src/main/java/com/example/demo/service/project/ProjectService.java
+++ b/src/main/java/com/example/demo/service/project/ProjectService.java
@@ -8,11 +8,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public interface ProjectService {
 
-    public Project save(Project project);
+    Project save(Project project);
 
-    public Project findById(Long id);
+    Project findById(Long id);
 
-    public List<Project> findProjectsByUser(User user);
+    List<Project> findProjectsByUser(User user);
 
-    public int countProjectsByUser(User user);
+    int countProjectsByUser(User user);
 }

--- a/src/main/java/com/example/demo/service/project/ProjectTechnologyService.java
+++ b/src/main/java/com/example/demo/service/project/ProjectTechnologyService.java
@@ -8,8 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public interface ProjectTechnologyService {
 
-    public ProjectTechnology save(ProjectTechnology projectTechnology);
+    ProjectTechnology save(ProjectTechnology projectTechnology);
 
-    public ProjectTechnology getProjectTechnologyEntity(
-            Project project, TechnologyStack technologyStack);
+    ProjectTechnology getProjectTechnologyEntity(Project project, TechnologyStack technologyStack);
 }


### PR DESCRIPTION
### 작업내용
- 인터페이스 추상 메소드에 명시적으로 설정해놓은 'public' 접근 제어자 삭제
- 추상 메소드의 구현부(인터페이스 멤버)와 접근 제어자 중복 경고 문제 해결