### PR TITLE
[fix/count-query-return-type-warning] 데이터 개수 카운트 쿼리 반환 타입 수정 및 경고 해결

### DIFF
--- a/src/main/java/com/example/demo/repository/alert/AlertRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/alert/AlertRepositoryCustom.java
@@ -17,5 +17,5 @@ public interface AlertRepositoryCustom {
     List<AlertSupportedProjectInfoResponseDto> findAlertsBySendUserIdAndTypeOrderByCreateDateDesc(Long sendUserId, Pageable pageable);
 
     // 조건별 알림 목록 개수 조회
-    long countAlertsTotalItem(Long projectId, Long sendUserId, AlertType type);
+    Long countAlertsTotalItem(Long projectId, Long sendUserId, AlertType type);
 }

--- a/src/main/java/com/example/demo/repository/alert/AlertRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/alert/AlertRepositoryImpl.java
@@ -112,7 +112,7 @@ public class AlertRepositoryImpl implements AlertRepositoryCustom{
 
     @Override
     // 알람 전체 개수 조회 (조건)
-    public long countAlertsTotalItem(Long projectId, Long sendUserId, AlertType alertType) {
+    public Long countAlertsTotalItem(Long projectId, Long sendUserId, AlertType alertType) {
         return jpaQueryFactory
                 .select(qAlert.count())
                 .from(qAlert)


### PR DESCRIPTION
### 작업내용
- AlertRepositoryCustom, AlertRepositoryImpl에서 알림 목록의 개수를 카운트하는 쿼리의 반환 타입을 long -> Long 타입으로 수정
- 기존 long 타입을 반환하는 경우 만약 특정 조건의 데이터가 존재하지 않으면 NullPointException을 발생시킨다는 경고 문제 해결, Long 타입을 반환하여 없는 경우 null 값을 반환하도록 수정