### PR TITLE
fix : docker-compose 버전 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.8'
 
 services:
   redis:


### PR DESCRIPTION
### 🔥 작업내용
- docker 엔진과의 호환성을 위해 docker-compose 버전을 3 -> 3.8 버전으로 변경

### 📚 연관이슈