### PR TITLE
fix : 도커 컴포즈를 통해 스프링부트와 레디스를 함께 실행하도록 배포 스크립트 수정

### DIFF
--- a/.github/workflows/deploy-cicd.yml
+++ b/.github/workflows/deploy-cicd.yml
@@ -42,14 +42,10 @@ jobs:
     - name: Deploy
       uses: appleboy/ssh-action@master
       with:
-        host: ${{ secrets.EC2_HOST }} # EC2 인스턴스 퍼블릭 DNS
+        host: ${{ secrets.EC2_HOST }}
         username: ubuntu
-        key: ${{ secrets.PRIVATE_KEY }} # EC2 pem 키
-        # 도커 작업
+        key: ${{ secrets.PRIVATE_KEY }}
         script: |
-          docker pull ${{ secrets.DOCKER_USERNAME }}/projectmatch:latest
-          docker stop $(docker ps -a -q)
-          docker run -d --log-driver=syslog -p 8080:8080 -e SPRING_PROFILES_ACTIVE=prod ${{ secrets.DOCKER_USERNAME }}/projectmatch:latest
-          docker rm $(docker ps --filter 'status=exited' -a -q)
-          docker image prune -a -f
+          docker-compose -f /home/ubuntu/compose/docker-compose.yml down --rmi all
+          docker-compose -f /home/ubuntu/compose/docker-compose.yml up -d
 


### PR DESCRIPTION
### 🔥 작업내용
- 기존 베포 환경에서 도커로 스프링부트 서버를 실행하고 AWS ElastiCache로 Reids를 실행하는 방법에서 도커 컴포즈로 스프링부트와 레디스를 함께 실행하도록 수정

### 📚 연관이슈
- 