### PR TITLE
배포환경의 도커 컴포즈 명령어 수정

### DIFF
--- a/.github/workflows/deploy-cicd.yml
+++ b/.github/workflows/deploy-cicd.yml
@@ -46,6 +46,7 @@ jobs:
         username: ubuntu
         key: ${{ secrets.PRIVATE_KEY }}
         script: |
+          docker-compose -f /home/ubuntu/compose/docker-compose.yml pull
           docker-compose -f /home/ubuntu/compose/docker-compose.yml down --rmi all
-          docker-compose -f /home/ubuntu/compose/docker-compose.yml up -d
+          docker-compose -f /home/ubuntu/compose/docker-compose.yml up -d --force-recreate
 


### PR DESCRIPTION
🔥 작업내용
- 최신 수정된 작업이 배포환경에 적용되지 않는 버그 수정
- 배포과정에서 최신 이미지를 pull 해오고 가져온 최신 이미지로 새로운 컨테이너를 재생성하도록 수정

📚 연관이슈
- 
